### PR TITLE
Update README.md to correct iOS version for NSIncrementalStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Don't forget to pull down AFNetworking with `git submodule init && git submodule
 
 ## Requirements
 
-AFIncrementalStore requires [iOS 4.0](http://developer.apple.com/library/ios/#releasenotes/General/WhatsNewIniPhoneOS/Articles/iPhoneOS4.html) and above, or [Mac OS 10.6](http://developer.apple.com/library/mac/#releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_6.html#//apple_ref/doc/uid/TP40008898-SW7) ([64-bit with modern Cocoa runtime](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtVersionsPlatforms.html)) and above, as well as [AFNetworking](https://github.com/afnetworking/afnetworking) 0.9 or higher.
+AFIncrementalStore requires [iOS 5.0](http://developer.apple.com/library/ios/#releasenotes/General/WhatsNewIniPhoneOS/Articles/iOS5.html) and above, or [Mac OS 10.6](http://developer.apple.com/library/mac/#releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_6.html#//apple_ref/doc/uid/TP40008898-SW7) ([64-bit with modern Cocoa runtime](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtVersionsPlatforms.html)) and above, as well as [AFNetworking](https://github.com/afnetworking/afnetworking) 0.9 or higher.
 
 ## Next Steps
 


### PR DESCRIPTION
From iOS 4 to iOS 5, in according with NSIncrementalStore's availability (http://developer.apple.com/library/ios/#documentation/CoreData/Reference/NSIncrementalStore_Class/Reference/NSIncrementalStore.html#//apple_ref/occ/cl/NSIncrementalStore)
