### PR TITLE
Main thread blocked by many context read/write operations 

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -98,10 +98,12 @@ NSString * AFIncrementalStoreUnimplementedMethodException = @"com.alamofire.incr
                     NSString *resourceIdentifier = [self.HTTPClient resourceIdentifierForRepresentation:representation ofEntity:entity];
                     
                     NSManagedObjectID *objectID = [self newObjectIDForEntity:entity referenceObject:resourceIdentifier];
-                    
-                    NSManagedObject *managedObject = [context existingObjectWithID:objectID error:error];
                     NSDictionary *propertyValues = [self.HTTPClient propertyValuesForRepresentation:representation ofEntity:entity fromResponse:operation.response];
-                    [managedObject setValuesForKeysWithDictionary:propertyValues];
+
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                        NSManagedObject *managedObject = [context existingObjectWithID:objectID error:error];
+                        [managedObject setValuesForKeysWithDictionary:propertyValues];
+                    });
                     
                     [self cachePropertyValues:propertyValues forObjectID:objectID];
                 }];
@@ -113,6 +115,7 @@ NSString * AFIncrementalStoreUnimplementedMethodException = @"com.alamofire.incr
                 NSLog(@"Error: %@", error);
             }];
             
+            operation.successCallbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
             [self.HTTPClient enqueueHTTPRequestOperation:operation];
         }
 


### PR DESCRIPTION
First, a little background about the issue. I was trying out AFIncrementalStore, and added to an existent project. This has an API call in which it fetches 40 objects, it's not a huge number, but a little bigger than the current calls made in the sample app (http://afincrementalstore-example-api.herokuapp.com).

So, I've discovered, that, as the whole AFHTTPRequestOperation is being executed in the main queue, and it enumerates the response objects with concurrency. And because Core Data operations to read/write are executed in the main queue. It was blocking it. That caused that the UI stopped working, and the fetch never finishes.

After some time debugging and trying to fix the problem. Found that if the Request Operation is executed in a secondary queue, and reading/writing to the Managed Context in the main queue, it fixes the problem. So, I've fixed it in a branch in my fork, and it works fine with my project and the sample app. I'm not an expert in NSIncerementStore, so I suggest taking a deep look at the fix, but as said everything should be working fine.
