### PR TITLE
Need to change propertyValuesForRepresentation to attributesForRepresentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The only thing you need to do is tell `AFIncrementalStore` how to map Core Data 
 - (NSString *)resourceIdentifierForRepresentation:(NSDictionary *)representation
                                          ofEntity:(NSEntityDescription *)entity;
 
-- (NSDictionary *)propertyValuesForRepresentation:(NSDictionary *)representation
+- (NSDictionary *)attributesForRepresentation:(NSDictionary *)representation
                                          ofEntity:(NSEntityDescription *)entity
                                      fromResponse:(NSHTTPURLResponse *)response;
 


### PR DESCRIPTION
It appears that `propertyValuesForRepresentation:` has been changed to `attributesForRepresentation:`

This needs to be reflected in the README to avoid confusion.
