### PR TITLE
Do not add resource identifier in subentities

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -71,6 +71,10 @@ static NSString * const kAFIncrementalStoreResourceIdentifierAttributeName = @"_
         
         NSManagedObjectModel *model = [self.persistentStoreCoordinator.managedObjectModel copy];
         for (NSEntityDescription *entity in model.entities) {
+            // Skip subentity in entity inheritance hierarchy. The root entity inherits from NSManagedObject and thus has no superentity set.
+            // All subentities of the root entity in an inheritance hierarchy will contain the attribute description anyway.
+            if (nil != [entity superentity]) continue;
+            
             NSAttributeDescription *resourceIdentifierProperty = [[NSAttributeDescription alloc] init];
             [resourceIdentifierProperty setName:kAFIncrementalStoreResourceIdentifierAttributeName];
             [resourceIdentifierProperty setAttributeType:NSStringAttributeType];


### PR DESCRIPTION
All subentities of a root entity in an inheritance hierarchy contain the attribute description anyway (due to how inheritance works). If we add the resource identifier in all entities, -[NSEntityDescription setProperties:] raises an exception when adding the same property in a subentity of an entity to which the attribute description was already added.
