### PR TITLE
Extract only attributes from representation

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -121,7 +121,7 @@ static NSString * AFPluralizedString(NSString *string) {
     NSMutableDictionary *mutableAttributes = [representation mutableCopy];
     @autoreleasepool {
         NSMutableSet *mutableKeys = [NSMutableSet setWithArray:[representation allKeys]];
-        [mutableKeys minusSet:[NSSet setWithArray:[[entity propertiesByName] allKeys]]];
+        [mutableKeys minusSet:[NSSet setWithArray:[[entity attributesByName] allKeys]]];
         [mutableAttributes removeObjectsForKeys:[mutableKeys allObjects]];
     }
     


### PR DESCRIPTION
AFRESTClient should only return attributes when askt to extract the attributes from the dictionary representation. Just removing collections seems not to be sufficient in some cases.
