### PR TITLE
Fix basic example on iOS 6 and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*xcuserdata/
+*build/
+*.mode1v3
+*.pbxuser
+*.xcworkspace
+*.moved-aside/
+DerivedData

--- a/Examples/Basic Example/AppDelegate.m
+++ b/Examples/Basic Example/AppDelegate.m
@@ -39,7 +39,7 @@
     self.navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
     
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    [self.window addSubview:self.navigationController.view];
+	self.window.rootViewController = self.navigationController;
     [self.window makeKeyAndVisible];
     
     return YES;

--- a/Examples/Twitter Client/AppDelegate.m
+++ b/Examples/Twitter Client/AppDelegate.m
@@ -40,7 +40,7 @@
     self.navigationController.navigationBar.tintColor = [UIColor darkGrayColor];
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    [self.window addSubview:self.navigationController.view];
+    self.window.rootViewController = self.navigationController;
     [self.window makeKeyAndVisible];
     
     return YES;

--- a/Examples/Twitter Client/Classes/Tweet.m
+++ b/Examples/Twitter Client/Classes/Tweet.m
@@ -14,5 +14,6 @@
 @dynamic text;
 
 @dynamic user;
+@dynamic createdAt;
 
 @end

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The only thing you need to do is tell `AFIncrementalStore` how to map Core Data 
 
 Check out the example projects that are included in the repository. They are somewhat simple demonstration of an app that uses Core Data with `AFIncrementalStore` to communicate with an API for faulted properties and relationships. Note that there are no explicit network requests being made in the app--it's all done automatically by Core Data.
 
-Also, don't forget to pull down AFNetworking with `git submodule init && git submodule update` if you want to run the example. 
+Also, don't forget to pull down AFNetworking with `git submodule update --init` if you want to run the example. 
 
 ## Requirements
 


### PR DESCRIPTION
The Basic Example project wasn't using UIWindow's `rootViewController` property. In iOS 6, this breaks all kinds of stuff.

I also added a gitignore to ignore the Xcode project noise.
