### PR TITLE
Fix documentation typo and remove redundant notification

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -103,7 +103,7 @@
 /**
  Returns an `NSDictionary` containing the representations of associated objects found within the representation of a response object, keyed by their relationship name.
  
- @discussion For example, if `GET /albums/123` returned the representation of an album, including the tracks as sub-entities, keyed under `"tracks"`, this method would return a dictionary with an array of representations for those objects, keyed under the name of the relationship used in the model (which is likely also to be `"tracks"`). Likewise, if an album also contained a representation of its artist, that dictionary would contain a dictionary representation of that artist, keyed undrer the name of the relationship used in the model (which is likely also to be `"artist"`).
+ @discussion For example, if `GET /albums/123` returned the representation of an album, including the tracks as sub-entities, keyed under `"tracks"`, this method would return a dictionary with an array of representations for those objects, keyed under the name of the relationship used in the model (which is likely also to be `"tracks"`). Likewise, if an album also contained a representation of its artist, that dictionary would contain a dictionary representation of that artist, keyed under the name of the relationship used in the model (which is likely also to be `"artist"`).
  
  @param representation The resource representation.
  @param entity The entity for the representation.

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -153,10 +153,6 @@ static NSString * const kAFIncrementalStoreResourceIdentifierAttributeName = @"_
                 NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
                 childContext.parentContext = context;
                 childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
-                
-                [[NSNotificationCenter defaultCenter] addObserverForName:NSManagedObjectContextDidSaveNotification object:childContext queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-                    [context mergeChangesFromContextDidSaveNotification:note];
-                }];
 
                 NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
                 [childContext performBlock:^{


### PR DESCRIPTION
Just a bit of housekeeping - found a (one char!) typo in the new docs, which are excellent and a great help btw!

Also, unless I'm missing something, I don't believe the fetch request context needs to merge changes from it's direct children via notifications, as Core Data should do that automatically.
