### PR TITLE
Fix pluralization for words ending in 'ge'

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -23,7 +23,7 @@
 #import "AFRESTClient.h"
 
 static NSString * AFPluralizedString(NSString *string) {
-    if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ge"] || [string hasSuffix:@"ch"]) {
+    if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ch"]) {
         return [[string stringByAppendingString:@"es"] lowercaseString];
     } else {
         return [[string stringByAppendingString:@"s"] lowercaseString];


### PR DESCRIPTION
Please feel free to correct me if I'm wrong here, as I have very little knowledge in linguistics, but this came up due to a "Message" entity. I found a page with words ending in "ge" and they all seemed to require a "s" instead of an "es" suffix.
