### PR TITLE
Expose mutable URL requests in AFRestClient

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -155,7 +155,7 @@
  
  @return An `NSURLRequest` object corresponding to the specified fetch request.
  */
-- (NSURLRequest *)requestForFetchRequest:(NSFetchRequest *)fetchRequest
+- (NSMutableURLRequest *)requestForFetchRequest:(NSFetchRequest *)fetchRequest
                              withContext:(NSManagedObjectContext *)context;
 
 /**
@@ -169,7 +169,7 @@
  
  @return An `NSURLRequest` object with the provided HTTP method for the resource corresponding to the managed object.
  */
-- (NSURLRequest *)requestWithMethod:(NSString *)method
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                 pathForObjectWithID:(NSManagedObjectID *)objectID
                         withContext:(NSManagedObjectContext *)context;
 
@@ -186,7 +186,7 @@
  @return An `NSURLRequest` object with the provided HTTP method for the resource or resoures corresponding to the relationship of the managed object.
 
  */
-- (NSURLRequest *)requestWithMethod:(NSString *)method
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                 pathForRelationship:(NSRelationshipDescription *)relationship
                     forObjectWithID:(NSManagedObjectID *)objectID
                         withContext:(NSManagedObjectContext *)context;

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -23,7 +23,7 @@
 #import "AFRESTClient.h"
 
 static NSString * AFPluralizedString(NSString *string) {
-    if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ge"] || [string hasSuffix:@"ch"]) {
+    if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ch"]) {
         return [[string stringByAppendingString:@"es"] lowercaseString];
     } else {
         return [[string stringByAppendingString:@"s"] lowercaseString];

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -137,7 +137,7 @@ static NSString * AFPluralizedString(NSString *string) {
     return mutableAttributes;
 }
 
-- (NSURLRequest *)requestForFetchRequest:(NSFetchRequest *)fetchRequest 
+- (NSMutableURLRequest *)requestForFetchRequest:(NSFetchRequest *)fetchRequest
                              withContext:(NSManagedObjectContext *)context
 {
     NSMutableURLRequest *mutableRequest =  [self requestWithMethod:@"GET" path:[self pathForEntity:fetchRequest.entity] parameters:nil];
@@ -146,7 +146,7 @@ static NSString * AFPluralizedString(NSString *string) {
     return mutableRequest;
 }
 
-- (NSURLRequest *)requestWithMethod:(NSString *)method
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                 pathForObjectWithID:(NSManagedObjectID *)objectID
                         withContext:(NSManagedObjectContext *)context
 {
@@ -154,7 +154,7 @@ static NSString * AFPluralizedString(NSString *string) {
     return [self requestWithMethod:method path:[self pathForObject:object] parameters:nil];
 }
 
-- (NSURLRequest *)requestWithMethod:(NSString *)method
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
                 pathForRelationship:(NSRelationshipDescription *)relationship
                     forObjectWithID:(NSManagedObjectID *)objectID
                         withContext:(NSManagedObjectContext *)context


### PR DESCRIPTION
I think that this would allow for easier subclassing of AFRestClient. For example, in my case, I need to add a custom OAuth header with signature on a per request basis.
