### PR TITLE
Support relation by foreign id

### DIFF
--- a/AFIncrementalStore/AFRESTClient.h
+++ b/AFIncrementalStore/AFRESTClient.h
@@ -64,4 +64,9 @@
 - (NSString *)pathForRelationship:(NSRelationshipDescription *)relationship
                         forObject:(NSManagedObject *)object;
 
+/**
+ Set to `YES` to support relationship mapping by `name_id`. Such relation usualy returned by Ruby on Rails. This is `NO` by default.
+ */
+@property (nonatomic, assign) BOOL supportRelationsByID;
+
 @end

--- a/AFIncrementalStore/AFRESTClient.h
+++ b/AFIncrementalStore/AFRESTClient.h
@@ -70,3 +70,12 @@
 @property (nonatomic, assign) BOOL supportRelationsByID;
 
 @end
+
+///----------------
+/// @name Functions
+///----------------
+
+/**
+ Returns pluralized string.
+ */
+extern NSString * AFPluralizedString(NSString *string);

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -80,8 +80,13 @@ NSString * AFPluralizedString(NSString *string) {
     [entity.relationshipsByName enumerateKeysAndObjectsUsingBlock:^(id name, id relationship, BOOL *stop) {
         NSString *relationKey = name;
         if (self.supportRelationsByID) {
+            if ([relationship isToMany] && [relationKey hasSuffix:@"s"]) {
+                relationKey = [relationKey substringToIndex:(relationKey.length - 1)];
+            }
             relationKey = [relationKey stringByAppendingString:@"_id"];
-            if ([relationship isToMany]) relationKey = [relationKey stringByAppendingString:@"s"];
+            if ([relationship isToMany]) {
+                relationKey = [relationKey stringByAppendingString:@"s"];
+            }
         }
         
         id value = [representation valueForKey:relationKey];

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -104,10 +104,10 @@ NSString * AFPluralizedString(NSString *string) {
                     arrayOfRelationshipRepresentations = [NSArray arrayWithObject:value];
                 }
                                 
-                [mutableRelationshipRepresentations setValue:arrayOfRelationshipRepresentations forKey:relationKey];
+                [mutableRelationshipRepresentations setValue:arrayOfRelationshipRepresentations forKey:name];
             } else {
                 if (self.supportRelationsByID) value = @{@"id" : value};
-                [mutableRelationshipRepresentations setValue:value forKey:relationKey];
+                [mutableRelationshipRepresentations setValue:value forKey:name];
             }
         }
     }];

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -23,7 +23,7 @@
 #import "AFRESTClient.h"
 #import "ISO8601DateFormatter.h"
 
-static NSString * AFPluralizedString(NSString *string) {
+NSString * AFPluralizedString(NSString *string) {
     if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ch"]) {
         return [[string stringByAppendingString:@"es"] lowercaseString];
     } else {


### PR DESCRIPTION
Currently relations are supported by searching `relationName` in `representation`

This hack allows building relations by using `relationName_id` or `relationName_ids`, as many Ruby on Rails engines return.
