### PR TITLE
Fixes object ID caching, relationship importing crasher

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -62,7 +62,17 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 @dynamic af_resourceIdentifier;
 
 - (NSString *)af_resourceIdentifier {
-    return (NSString *)objc_getAssociatedObject(self, &kAFResourceIdentifierObjectKey);
+
+    NSString *identifier = (NSString *)objc_getAssociatedObject(self, &kAFResourceIdentifierObjectKey);
+    
+    if (!identifier) {
+        if ([self.objectID.persistentStore isKindOfClass:[AFIncrementalStore class]]) {
+            return [(AFIncrementalStore *)self.objectID.persistentStore referenceObjectForObjectID:self.objectID];
+        }
+    }
+    
+    return identifier;
+    
 }
 
 - (void)af_setResourceIdentifier:(NSString *)resourceIdentifier {
@@ -345,6 +355,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             for (NSString *resourceIdentifier in [results valueForKeyPath:kAFIncrementalStoreResourceIdentifierAttributeName]) {
                 NSManagedObjectID *objectID = [self objectIDForEntity:fetchRequest.entity withResourceIdentifier:resourceIdentifier];
                 NSManagedObject *object = [context objectWithID:objectID];
+                object.af_resourceIdentifier = resourceIdentifier;
                 [mutableObjects addObject:object];
             }
             


### PR DESCRIPTION
- Fixes a case where different entities sharing the same reference object namespace will have their object IDs collide with each other.
- Fixes a crasher happening during relationship imports if the incoming representation is not for one or many entities.
- Fixes an issue where the relationships may be set up between objects from different managed object contexts during relationship imports.
