### PR TITLE
Fixes superfluous change merging triggered by loading remote relationships; initial pluggable value transformer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside

--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -18,4 +18,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.dependency 'AFNetworking', '>= 0.9.0'
+  s.dependency 'RASchedulingKit', :git => 'https://github.com/evadne/RASchedulingKit.git'
+  
 end

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -118,7 +118,12 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     [userInfo setObject:operation forKey:AFIncrementalStoreRequestOperationKey];
     [userInfo setObject:fetchRequest forKey:AFIncrementalStorePersistentStoreRequestKey];
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:context userInfo:userInfo];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:context userInfo:userInfo];
+        
+    });
+
 }
 
 - (void)notifyManagedObjectContext:(NSManagedObjectContext *)context

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -349,9 +349,13 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                         
             [childContext performBlock:^{
                 [self insertOrUpdateObjectsFromRepresentations:representationOrArrayOfRepresentations ofEntity:fetchRequest.entity fromResponse:operation.response withContext:childContext error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
+                
                     if (![[self backingManagedObjectContext] save:error] || ![childContext save:error]) {
-                        NSLog(@"Error: %@", *error);
+                        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Saving failed." userInfo:@{
+                            NSUnderlyingErrorKey: *error
+                        }];
                     }
+                    
                 }];
                 
                 [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest];

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -434,15 +434,10 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     
 }
 
-- (void) saveBackingManagedObjects:(NSArray *)backingObjects inContext:(NSManagedObjectContext *)backingContext refreshingManagedObjects:(NSArray *)managedObjects inContext:(NSManagedObjectContext *)managedContext {
+- (void) saveBackingObjects:(NSArray *)backingObjects inContext:(NSManagedObjectContext *)backingContext {
 
     for (NSManagedObject *backingObject in backingObjects)
         NSCParameterAssert([backingObject af_isPermanent]);
-    
-    for (NSManagedObject *managedObject in managedObjects)
-        NSCParameterAssert([managedObject af_isPermanent]);
-    
-    NSSet *refreshedManagedObjects = [NSSet setWithArray:managedObjects];
     
     NSError *backingContextSavingError;
     if (![backingContext save:&backingContextSavingError]) {
@@ -450,6 +445,18 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             NSUnderlyingErrorKey: backingContextSavingError
         }];
     }
+    
+    for (NSManagedObject *backingObject in backingObjects)
+        NSCParameterAssert(![[backingObject changedValues] count]);
+
+}
+
+- (void) refreshManagedObjects:(NSArray *)managedObjects inContext:(NSManagedObjectContext *)managedContext {
+
+    for (NSManagedObject *managedObject in managedObjects)
+        NSCParameterAssert([managedObject af_isPermanent]);
+    
+    NSSet *refreshedManagedObjects = [NSSet setWithArray:managedObjects];
     
     NSManagedObjectContext *parentContext = managedContext.parentContext;
 
@@ -492,9 +499,13 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     
     for (NSManagedObject *managedObject in managedObjects)
         NSCParameterAssert(![[managedObject changedValues] count]);
-    
-    for (NSManagedObject *backingObject in backingObjects)
-        NSCParameterAssert(![[backingObject changedValues] count]);
+
+}
+
+- (void) saveBackingManagedObjects:(NSArray *)backingObjects inContext:(NSManagedObjectContext *)backingContext refreshingManagedObjects:(NSArray *)managedObjects inContext:(NSManagedObjectContext *)managedContext {
+
+    [self saveBackingObjects:backingObjects inContext:backingContext];
+    [self refreshManagedObjects:managedObjects inContext:managedContext];
 
 }
 

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -577,7 +577,11 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     fetchRequest.propertiesToFetch = [[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allKeys];
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"%K = %@", kAFIncrementalStoreResourceIdentifierAttributeName, [self referenceObjectForObjectID:objectID]];
     
-    NSArray *results = [[self backingManagedObjectContext] executeFetchRequest:fetchRequest error:error];
+    __block NSArray *results;
+    NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
+    [backingContext performBlockAndWait:^{
+        results = [backingContext executeFetchRequest:fetchRequest error:error];
+    }];
     NSDictionary *attributeValues = [results lastObject] ?: [NSDictionary dictionary];
 
     NSIncrementalStoreNode *node = [[NSIncrementalStoreNode alloc] initWithObjectID:objectID withValues:attributeValues version:1];

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -564,11 +564,11 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     if ([request URL]) {
         AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
             
-            id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
+            NSArray *representations = [self representationsFromResponseObject:responseObject];
             
             [self performUpdatesWithParentContext:context usingBlock:^(NSManagedObjectContext *childContext) {
                 
-                [self insertOrUpdateObjectsFromRepresentations:representationOrArrayOfRepresentations ofEntity:fetchRequest.entity fromResponse:operation.response withContext:childContext error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
+                [self insertOrUpdateObjectsFromRepresentations:representations ofEntity:fetchRequest.entity fromResponse:operation.response withContext:childContext error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
                 
                     [self saveBackingManagedObjects:backingObjects inContext:[self backingManagedObjectContext] refreshingManagedObjects:managedObjects inContext:childContext];
                                     
@@ -634,182 +634,290 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     }
 }
 
-- (id)executeSaveChangesRequest:(NSSaveChangesRequest *)saveChangesRequest
-                    withContext:(NSManagedObjectContext *)context
-                          error:(NSError *__autoreleasing *)error
-{
-    NSMutableArray *mutableOperations = [NSMutableArray array];
+- (void) obtainPermanentIDForTemporaryObject:(NSManagedObject *)object withResourceIdentifier:(NSString *)resourceIdentifier {
+    
+    NSCParameterAssert(![object af_isPermanent]);
+    
+    object.af_resourceIdentifier = resourceIdentifier;
+    
+    [object willChangeValueForKey:@"objectID"];
+    
+    NSError *permanentIDsObtainingError = nil;
+    BOOL didObtainPermanentIDs = [object.managedObjectContext obtainPermanentIDsForObjects:[NSArray arrayWithObject:object] error:&permanentIDsObtainingError];
+    
+    if (!didObtainPermanentIDs)
+        NSLog(@"%s: %@", __PRETTY_FUNCTION__, permanentIDsObtainingError);
+
+    [object didChangeValueForKey:@"objectID"];
+    
+    NSCParameterAssert([object af_isPermanent]);
+
+}
+
+- (void) updateRelationshipsOfBackingObject:(NSManagedObject *)backingObject withRelationshipsOfManagedObject:(NSManagedObject *)insertedObject {
+    
+    NSManagedObjectContext *backingContext = backingObject.managedObjectContext;
+    
+    [[insertedObject.entity relationshipsByName] enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSRelationshipDescription *relationship, BOOL *stop) {
+    
+        id requestedRelationship = [insertedObject valueForKey:name];
+        if (!requestedRelationship)
+            return;
+        
+        id providedRelationship = nil;
+        
+        NSManagedObject * (^backingObjectForManagedObject)(NSManagedObject *) = ^ (NSManagedObject *incomingObject) {
+        
+            return [self backingObjectInContext:backingContext forManagedObject:incomingObject];
+        
+        };
+        
+        if ([relationship isToMany]) {
+        
+            if ([relationship isOrdered]) {
+            
+                providedRelationship = [NSMutableOrderedSet orderedSet];
+                for (NSManagedObject *relationshipObject in (NSOrderedSet *)requestedRelationship) {
+                    NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
+                    if (relatedObject) {
+                        [(NSMutableOrderedSet *)providedRelationship addObject:relatedObject];
+                    } else {
+                        NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
+                    }
+                }
+            
+            } else {
+            
+                providedRelationship = [NSMutableSet set];
+                for (NSManagedObject *relationshipObject in (NSSet *)requestedRelationship) {
+                    NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
+                    if (relatedObject) {
+                        [(NSMutableSet *)providedRelationship addObject:relatedObject];
+                    } else {
+                        NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
+                    }
+                }
+                
+            }
+        
+        } else {
+        
+            NSManagedObject *relationshipObject = (NSManagedObject *)requestedRelationship;
+            NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
+            if (relatedObject) {
+                providedRelationship = relatedObject;
+            } else {
+                NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
+            }
+        
+        }
+        
+        [backingObject setValue:providedRelationship forKey:name];
+        
+    }];
+
+}
+
+- (void) assertManagedObject:(NSManagedObject *)managedObject hasAssociationsEquivalentToBackingObject:(NSManagedObject *)backingObject {
+
+    NSDictionary *backingRelationships = backingObject.entity.relationshipsByName;
+    NSDictionary *managedRelationships = managedObject.entity.relationshipsByName;
+    NSCParameterAssert([backingRelationships count] == [managedRelationships count]);
+    NSCParameterAssert([[backingRelationships allKeys] isEqualToArray:[managedRelationships allKeys]]);
+    [backingRelationships enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSRelationshipDescription*backingRelationship, BOOL *stop) {
+        if ([backingObject valueForKey:name]) {
+            NSCParameterAssert([managedObject valueForKey:name]);
+        } else {
+            NSCParameterAssert(![managedObject valueForKey:name]);
+        }
+    }];
+
+}
+
+- (NSArray *) operationsForInsertedObject:(NSManagedObject *)insertedObject {
+
+    AFHTTPClient<AFIncrementalStoreHTTPClient> *httpClient = self.HTTPClient;
     NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
+    
+    if (![httpClient respondsToSelector:@selector(requestForInsertedObject:)])
+        return @[];
 
-    if ([self.HTTPClient respondsToSelector:@selector(requestForInsertedObject:)]) {
-        for (NSManagedObject *insertedObject in [saveChangesRequest insertedObjects]) {
-            NSURLRequest *request = [self.HTTPClient requestForInsertedObject:insertedObject];
-            AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-                
-                NSEntityDescription *entity = insertedObject.entity;
-                NSHTTPURLResponse *response = operation.response;
-                
-                NSString *resourceIdentifier = [self.HTTPClient resourceIdentifierForRepresentation:responseObject ofEntity:entity fromResponse:response];
+    NSURLRequest *request = [httpClient requestForInsertedObject:insertedObject];
+    if (!request)
+        return @[];
+    
+    AFHTTPRequestOperation *operation = [httpClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        
+        NSEntityDescription *entity = insertedObject.entity;
+        NSHTTPURLResponse *response = operation.response;
+        
+        NSString *resourceIdentifier = [self.HTTPClient resourceIdentifierForRepresentation:responseObject ofEntity:entity fromResponse:response];
 
-                NSDictionary *attributes = [self.HTTPClient attributesForRepresentation:responseObject ofEntity:entity fromResponse:response];
-                
-                NSManagedObjectID *objectID = [self objectIDForEntity:[insertedObject entity] withResourceIdentifier:resourceIdentifier];
-                insertedObject.af_resourceIdentifier = resourceIdentifier;
-                [insertedObject setValuesForKeysWithDictionary:attributes];
-                
-                __block NSManagedObject *backingObject = nil;
-                
-                if (objectID) {
-                    [backingContext performBlockAndWait:^{
-                        backingObject = [backingContext existingObjectWithID:objectID error:nil];
-                    }];
-                }
-                
-                if (!backingObject) {
-                    backingObject = [NSEntityDescription insertNewObjectForEntityForName:insertedObject.entity.name inManagedObjectContext:backingContext];
-                    [backingObject.managedObjectContext obtainPermanentIDsForObjects:@[ backingObject ] error:nil];
-                }
-                
-                NSCParameterAssert(backingObject);
-                NSCParameterAssert(backingObject.objectID);
-                NSCParameterAssert(![backingObject.objectID isTemporaryID]);
-                
-                [backingObject setValue:resourceIdentifier forKey:kAFIncrementalStoreResourceIdentifierAttributeName];
-                [backingObject setValuesForKeysWithDictionary:attributes];
-                
-                [[insertedObject.entity relationshipsByName] enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSRelationshipDescription *relationship, BOOL *stop) {
-                   
-                    id requestedRelationship = [insertedObject valueForKey:name];
-                    if (!requestedRelationship)
-                        return;
-                    
-                    id providedRelationship = nil;
-                    
-                    NSManagedObject * (^backingObjectForManagedObject)(NSManagedObject *) = ^ (NSManagedObject *incomingObject) {
-                    
-                        return [self backingObjectInContext:backingContext forManagedObject:incomingObject];
-                    
-                    };
-                    
-                    if ([relationship isToMany]) {
-                    
-                        if ([relationship isOrdered]) {
+        NSDictionary *attributes = [self.HTTPClient attributesForRepresentation:responseObject ofEntity:entity fromResponse:response];
+        
+        NSManagedObjectID *objectID = [self objectIDForEntity:[insertedObject entity] withResourceIdentifier:resourceIdentifier];
+        insertedObject.af_resourceIdentifier = resourceIdentifier;
+        [insertedObject setValuesForKeysWithDictionary:attributes];
+        
+        __block NSManagedObject *backingObject = nil;
+        
+        if (objectID) {
+            [backingContext performBlockAndWait:^{
+                backingObject = [backingContext existingObjectWithID:objectID error:nil];
+            }];
+        }
+        
+        if (!backingObject) {
+            backingObject = [NSEntityDescription insertNewObjectForEntityForName:insertedObject.entity.name inManagedObjectContext:backingContext];
+            [backingObject.managedObjectContext obtainPermanentIDsForObjects:@[ backingObject ] error:nil];
+        }
+        
+        NSCParameterAssert(backingObject);
+        NSCParameterAssert(backingObject.objectID);
+        NSCParameterAssert(![backingObject.objectID isTemporaryID]);
+        
+        [backingObject setValue:resourceIdentifier forKey:kAFIncrementalStoreResourceIdentifierAttributeName];
+        [backingObject setValuesForKeysWithDictionary:attributes];
+        
+        [self updateRelationshipsOfBackingObject:backingObject withRelationshipsOfManagedObject:insertedObject];
                         
-                            providedRelationship = [NSMutableOrderedSet orderedSet];
-                            for (NSManagedObject *relationshipObject in (NSOrderedSet *)requestedRelationship) {
-                                NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
-                                if (relatedObject) {
-                                    [(NSMutableOrderedSet *)providedRelationship addObject:relatedObject];
-                                } else {
-                                    NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
-                                }
-                            }
-                        
-                        } else {
-                        
-                            providedRelationship = [NSMutableSet set];
-                            for (NSManagedObject *relationshipObject in (NSSet *)requestedRelationship) {
-                                NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
-                                if (relatedObject) {
-                                    [(NSMutableSet *)providedRelationship addObject:relatedObject];
-                                } else {
-                                    NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
-                                }
-                            }
-                            
-                        }
-                    
-                    } else {
-                    
-                        NSManagedObject *relationshipObject = (NSManagedObject *)requestedRelationship;
-                        NSManagedObject *relatedObject = backingObjectForManagedObject(relationshipObject);
-                        if (relatedObject) {
-                            providedRelationship = relatedObject;
-                        } else {
-                            NSLog(@"%s: lost track of relationship object %@", __PRETTY_FUNCTION__, relationshipObject);
-                        }
-                    
-                    }
-                    
-                    [backingObject setValue:providedRelationship forKey:name];
-                    
-                }];
-                
-                [insertedObject willChangeValueForKey:@"objectID"];
-                
-                NSError *permanentIDsObtainingError = nil;
-                BOOL didObtainPermanentIDs = [context obtainPermanentIDsForObjects:[NSArray arrayWithObject:insertedObject] error:&permanentIDsObtainingError];
-                
-                if (!didObtainPermanentIDs)
-                    NSLog(@"%s: %@", __PRETTY_FUNCTION__, permanentIDsObtainingError);
-
-                [insertedObject didChangeValueForKey:@"objectID"];
-                
-                NSDictionary *backingRelationships = backingObject.entity.relationshipsByName;
-                NSDictionary *managedRelationships = insertedObject.entity.relationshipsByName;
-                NSCParameterAssert([backingRelationships count] == [managedRelationships count]);
-                NSCParameterAssert([[backingRelationships allKeys] isEqualToArray:[managedRelationships allKeys]]);
-                [backingRelationships enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSRelationshipDescription*backingRelationship, BOOL *stop) {
-                    if ([backingObject valueForKey:name]) {
-                        NSCParameterAssert([insertedObject valueForKey:name]);
-                    } else {
-                        NSCParameterAssert(![insertedObject valueForKey:name]);
-                    }
-                }];
-                
-                [self saveBackingManagedObjects:@[ backingObject ] inContext:backingContext refreshingManagedObjects:@[ insertedObject ] inContext:insertedObject.managedObjectContext];
-                
-            } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-                NSLog(@"Insert Error: %@", error);
+        [self obtainPermanentIDForTemporaryObject:insertedObject withResourceIdentifier:resourceIdentifier];
+        
+        [self assertManagedObject:insertedObject hasAssociationsEquivalentToBackingObject:backingObject];
+        
+        [self performUpdatesWithParentContext:insertedObject.managedObjectContext usingBlock:^(NSManagedObjectContext *childContext) {
+            
+            [self insertOrUpdateObjectsFromRepresentations:@[ responseObject ] ofEntity:entity fromResponse:operation.response withContext:childContext error:nil completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
+            
+                NSCParameterAssert([managedObjects count] == 1);
+                NSCParameterAssert([backingObjects count] == 1);
+            
+                [self saveBackingManagedObjects:backingObjects inContext:[self backingManagedObjectContext] refreshingManagedObjects:managedObjects inContext:childContext];
+                                
             }];
             
-            [mutableOperations addObject:operation];
-        }
-    }
-    
-    if ([self.HTTPClient respondsToSelector:@selector(requestForUpdatedObject:)]) {
-        for (NSManagedObject *updatedObject in [saveChangesRequest updatedObjects]) {
-            NSURLRequest *request = [self.HTTPClient requestForUpdatedObject:updatedObject];
-            AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-                [updatedObject setValuesForKeysWithDictionary:[self.HTTPClient attributesForRepresentation:responseObject ofEntity:updatedObject.entity fromResponse:operation.response]];
-                
-                [backingContext performBlockAndWait:^{
-                    NSManagedObject *backingObject = [backingContext existingObjectWithID:updatedObject.objectID error:nil];
-                    [backingObject setValuesForKeysWithDictionary:[updatedObject dictionaryWithValuesForKeys:nil]];
-                    [backingContext save:nil];
-                }];
-            } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-                NSLog(@"Update Error: %@", error);
-            }];
-            
-            [mutableOperations addObject:operation];
-        }
-    }
-    
-    if ([self.HTTPClient respondsToSelector:@selector(requestForDeletedObject:)]) {
-        for (NSManagedObject *deletedObject in [saveChangesRequest deletedObjects]) {
-            NSURLRequest *request = [self.HTTPClient requestForDeletedObject:deletedObject];
-            AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-                [backingContext performBlockAndWait:^{
-                    NSManagedObject *backingObject = [backingContext existingObjectWithID:deletedObject.objectID error:nil];
-                    [backingContext deleteObject:backingObject];
-                    [backingContext save:nil];
-                }];
-            } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-                NSLog(@"Delete Error: %@", error);
-            }];
-            
-            [mutableOperations addObject:operation];
-        }
-    }
-    
-    [self notifyManagedObjectContext:context aboutRequestOperations:mutableOperations forSaveChangesRequest:saveChangesRequest];
-
-    [self.HTTPClient enqueueBatchOfHTTPRequestOperations:mutableOperations progressBlock:nil completionBlock:^(NSArray *operations) {
-        [self notifyManagedObjectContext:context aboutRequestOperations:operations forSaveChangesRequest:saveChangesRequest];
+        }];
+                        
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        
+        NSLog(@"Insert Error: %@", error);
+        
     }];
     
-    return [NSArray array];
+    return @[ operation ];
+
+}
+
+- (NSArray *) operationsForUpdatedObject:(NSManagedObject *)updatedObject {
+
+    AFHTTPClient<AFIncrementalStoreHTTPClient> *httpClient = self.HTTPClient;
+    NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
+    
+    if (![httpClient respondsToSelector:@selector(requestForUpdatedObject:)])
+        return @[];
+    
+    NSURLRequest *request = [httpClient requestForUpdatedObject:updatedObject];
+    if (!request)
+        return nil;
+    
+    AFHTTPRequestOperation *operation = [httpClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    
+        [updatedObject setValuesForKeysWithDictionary:[httpClient attributesForRepresentation:responseObject ofEntity:updatedObject.entity fromResponse:operation.response]];
+        
+        [backingContext performBlockAndWait:^{
+            NSManagedObject *backingObject = [backingContext existingObjectWithID:updatedObject.objectID error:nil];
+            [backingObject setValuesForKeysWithDictionary:[updatedObject dictionaryWithValuesForKeys:nil]];
+            [backingContext save:nil];
+        }];
+        
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        
+        NSLog(@"Update Error: %@", error);
+        
+    }];
+    
+    return @[ operation ];
+
+}
+
+- (NSArray *) operationsForDeletedObject:(NSManagedObject *)deletedObject {
+
+    AFHTTPClient<AFIncrementalStoreHTTPClient> *httpClient = self.HTTPClient;
+    NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
+    
+    if (![self.HTTPClient respondsToSelector:@selector(requestForDeletedObject:)])
+        return @[];
+    
+    NSURLRequest *request = [httpClient requestForDeletedObject:deletedObject];
+    if (!request)
+        return nil;
+    
+    AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    
+        [backingContext performBlockAndWait:^{
+            
+            NSManagedObject *backingObject = [backingContext existingObjectWithID:deletedObject.objectID error:nil];
+            [backingContext deleteObject:backingObject];
+            [backingContext save:nil];
+            
+        }];
+        
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        
+        NSLog(@"Delete Error: %@", error);
+        
+    }];
+    
+    return @[ operation ];
+
+}
+
+- (NSArray *) operationsForSaveChangesRequest:(NSSaveChangesRequest *)saveChangesRequest {
+    
+    NSMutableArray *ops = [NSMutableArray array];
+    
+    NSSet *insertedObjects = [saveChangesRequest insertedObjects];
+    NSSet *updatedObjects = [saveChangesRequest updatedObjects];
+    NSSet *deletedObjects = [saveChangesRequest deletedObjects];
+    
+    for (NSManagedObject *insertedObject in insertedObjects)
+        [ops addObjectsFromArray:[self operationsForInsertedObject:insertedObject]];
+    
+    for (NSManagedObject *updatedObject in updatedObjects)
+        [ops addObjectsFromArray:[self operationsForUpdatedObject:updatedObject]];
+
+    for (NSManagedObject *deletedObject in deletedObjects)
+        [ops addObjectsFromArray:[self operationsForDeletedObject:deletedObject]];
+    
+    return ops;
+    
+}
+
+- (id) executeSaveChangesRequest:(NSSaveChangesRequest *)saveChangesRequest withContext:(NSManagedObjectContext *)context error:(NSError *__autoreleasing *)error {
+
+    //  TBD: AFIncrementalStore should subclass NSOperation directly, or provide a async harness that invokes customer-provided blocks, and allow overriding methods that emit the blocks and blocks that call callback blocks.  Give all the save components a scratchpad to play on, and if everything finished, store everything in a batch.  A potential implementation will involve a change request tree that gets appended by each save operation (emitted by -operationsForSaveChangesRequest: operations).
+    
+    //  This is related to the Undo Management problem: the incremental store does asynchronous data fulfillment, so if the customer changed some more data and things do not go through, we can not even revert.
+
+    NSArray *operations = [self operationsForSaveChangesRequest:saveChangesRequest];
+    if ([operations count]) {
+    
+        [self notifyManagedObjectContext:context aboutRequestOperations:operations forSaveChangesRequest:saveChangesRequest];
+        
+        [self.HTTPClient enqueueBatchOfHTTPRequestOperations:operations progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations) {
+            
+            //  ?
+            
+        } completionBlock:^(NSArray *operations) {
+        
+            [self notifyManagedObjectContext:context aboutRequestOperations:operations forSaveChangesRequest:saveChangesRequest];
+            
+        }];
+    
+    }
+    
+    return @[];
+    
 }
 
 #pragma mark -
@@ -1029,6 +1137,17 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     
 }
 
+- (NSArray *) representationsFromResponseObject:(id)responseObject {
+
+    id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
+    
+    if ([representationOrArrayOfRepresentations isKindOfClass:[NSArray class]])
+        return representationOrArrayOfRepresentations;
+    
+    return @[ representationOrArrayOfRepresentations ];
+    
+}
+
 - (void) fetchNewValueForRelationship:(NSRelationshipDescription *)relationship forObjectWithID:(NSManagedObjectID *)objectID withContext:(NSManagedObjectContext *)context usingBlock:(void(^)(id representationOrRepresentations, NSURLResponse *response, NSError *error))block {
     
     NSCParameterAssert(relationship);
@@ -1053,16 +1172,8 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     __weak typeof(self) wSelf = self;
     
     AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-
-        id representationOrArrayOfRepresentations = [wClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
-        
-        NSArray *representations = nil;
-        if ([representationOrArrayOfRepresentations isKindOfClass:[NSArray class]]) {
-            representations = representationOrArrayOfRepresentations;
-        } else {
-            representations = [NSArray arrayWithObject:representationOrArrayOfRepresentations];
-        }
-        
+    
+        NSArray *representations = [self representationsFromResponseObject:responseObject];
         if (![representations count]) {
             block(responseObject, operation.response, nil);
             return;
@@ -1070,7 +1181,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
         
         [self performUpdatesWithParentContext:context usingBlock:^(NSManagedObjectContext *childContext) {
             
-            [self insertOrUpdateObjectsFromRepresentations:representationOrArrayOfRepresentations ofEntity:relationship.destinationEntity fromResponse:operation.response withContext:childContext error:nil completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
+            [self insertOrUpdateObjectsFromRepresentations:representations ofEntity:relationship.destinationEntity fromResponse:operation.response withContext:childContext error:nil completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
 
                 NSManagedObject *managedObject = [childContext objectWithID:objectID];
                 NSString *referenceObject = [self referenceObjectForObjectID:objectID];

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -584,6 +584,10 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     fetchRequest.fetchLimit = 1;
     fetchRequest.includesSubentities = NO;
     fetchRequest.propertiesToFetch = [[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allKeys];
+    
+    //  Attempting to fetch an empty entity would cause issues
+    NSCParameterAssert([fetchRequest.propertiesToFetch count]);
+    
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"%K = %@", kAFIncrementalStoreResourceIdentifierAttributeName, [self referenceObjectForObjectID:objectID]];
     
     __block NSArray *results;

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -422,16 +422,11 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             
             NSManagedObject *rootObject = [parentContext objectWithID:registeredManagedObject.objectID];
             
-            NSLog(@"rootObject was %@", rootObject);
-
             [rootObject willChangeValueForKey:@"self"];
             [parentContext refreshObject:rootObject mergeChanges:NO];
             [rootObject didChangeValueForKey:@"self"];
             
-            NSLog(@"%s %@: %@", __PRETTY_FUNCTION__, rootObject, [rootObject changedValues]);
             NSCParameterAssert(![[rootObject changedValues] count]);
-            
-            NSLog(@"rootObject is %@", rootObject);
             
         }
 
@@ -441,17 +436,10 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
         
         for (NSManagedObject *registeredManagedObject in registeredManagedObjects) {
             
-            NSLog(@"registeredManagedObject was %@", registeredManagedObject);
-            
             [registeredManagedObject willChangeValueForKey:@"self"];
             [managedContext refreshObject:registeredManagedObject mergeChanges:NO];
             [registeredManagedObject didChangeValueForKey:@"self"];
             NSCParameterAssert(![[registeredManagedObject changedValues] count]);
-            
-            NSLog(@"%s %@: %@", __PRETTY_FUNCTION__, registeredManagedObject, [registeredManagedObject changedValues]);
-            NSCParameterAssert(![[registeredManagedObject changedValues] count]);
-            
-            NSLog(@"registeredManagedObject is %@", registeredManagedObject);
             
         }
         

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -215,7 +215,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 
     NSError *error = nil;
     NSManagedObjectID *objectID = [self backingObjectIDForEntity:entity resourceIdentifier:resourceIdentifier inContext:self.backingManagedObjectContext error:&error];
-    if (!objectID)
+    if (!objectID && error)
         NSLog(@"%s: %@", __PRETTY_FUNCTION__, error);
     
     return objectID;
@@ -271,10 +271,9 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     NSMutableArray *mutableBackingObjects = [NSMutableArray arrayWithCapacity:numberOfRepresentations];
     
     for (NSDictionary *representation in representations) {
+        
         NSString *resourceIdentifier = [self.HTTPClient resourceIdentifierForRepresentation:representation ofEntity:entity fromResponse:response];
         NSDictionary *attributes = [self.HTTPClient attributesForRepresentation:representation ofEntity:entity fromResponse:response];
-        
-        NSLog(@"grabbing %s", __PRETTY_FUNCTION__);
         
         NSManagedObject *managedObject = [context existingObjectWithID:[self objectIDForEntity:entity withResourceIdentifier:resourceIdentifier] error:nil];
         [managedObject setValuesForKeysWithDictionary:attributes];
@@ -365,7 +364,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
         AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
             id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
     
-            NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+            NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
             childContext.parentContext = context;
             childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
                         

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -416,12 +416,16 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                         }];
                     }
                     
-                    for (NSManagedObject *childObject in childObjects) {
-                        NSManagedObject *rootObject = [context objectWithID:childObject.objectID];
-                        [rootObject willChangeValueForKey:nil];
-                        [rootObject.managedObjectContext refreshObject:rootObject mergeChanges:NO];
-                        [rootObject didChangeValueForKey:nil];
-                    }
+                    [context performBlock:^{
+                        
+                        for (NSManagedObject *childObject in childObjects) {
+                            NSManagedObject *rootObject = [context objectWithID:childObject.objectID];
+                            [rootObject willChangeValueForKey:@"self"];
+                            [context refreshObject:rootObject mergeChanges:NO];
+                            [rootObject didChangeValueForKey:@"self"];
+                        }
+                    
+                    }];
                     
                 }];
                 

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -398,10 +398,10 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 - (void) saveBackingManagedObjects:(NSArray *)backingObjects inContext:(NSManagedObjectContext *)backingContext refreshingManagedObjects:(NSArray *)managedObjects inContext:(NSManagedObjectContext *)managedContext {
 
     for (NSManagedObject *backingObject in backingObjects)
-        NSCParameterAssert(backingObject.objectID && ![backingObject.objectID isTemporaryID]);
+        NSCParameterAssert([backingObject af_isPermanent]);
     
     for (NSManagedObject *managedObject in managedObjects)
-        NSCParameterAssert(managedObject.objectID && ![managedObject.objectID isTemporaryID]);
+        NSCParameterAssert([managedObject af_isPermanent]);
     
     NSSet *registeredManagedObjects = [[managedContext registeredObjects] objectsPassingTest:^(NSManagedObject *managedObject, BOOL *stop) {
         return (BOOL)(![managedObject.objectID isTemporaryID]);

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -578,6 +578,9 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                 [[insertedObject.entity relationshipsByName] enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSRelationshipDescription *relationship, BOOL *stop) {
                    
                     id requestedRelationship = [insertedObject valueForKey:name];
+                    if (!requestedRelationship)
+                        return;
+                    
                     id providedRelationship = nil;
                     
                     NSManagedObject * (^backingObjectForManagedObject)(NSManagedObject *) = ^ (NSManagedObject *incomingObject) {

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -62,7 +62,17 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 @dynamic af_resourceIdentifier;
 
 - (NSString *)af_resourceIdentifier {
-    return (NSString *)objc_getAssociatedObject(self, &kAFResourceIdentifierObjectKey);
+
+    NSString *identifier = (NSString *)objc_getAssociatedObject(self, &kAFResourceIdentifierObjectKey);
+    
+    if (!identifier) {
+        if ([self.objectID.persistentStore isKindOfClass:[AFIncrementalStore class]]) {
+            return [(AFIncrementalStore *)self.objectID.persistentStore referenceObjectForObjectID:self.objectID];
+        }
+    }
+    
+    return identifier;
+    
 }
 
 - (void)af_setResourceIdentifier:(NSString *)resourceIdentifier {
@@ -345,6 +355,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             for (NSString *resourceIdentifier in [results valueForKeyPath:kAFIncrementalStoreResourceIdentifierAttributeName]) {
                 NSManagedObjectID *objectID = [self objectIDForEntity:fetchRequest.entity withResourceIdentifier:resourceIdentifier];
                 NSManagedObject *object = [context objectWithID:objectID];
+                object.af_resourceIdentifier = resourceIdentifier;
                 [mutableObjects addObject:object];
             }
             

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -253,6 +253,13 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
         @throw [NSException exceptionWithName:AFIncrementalStoreRelationshipCardinalityException reason:@"Can not understand the representations." userInfo:nil];
     
     }
+    
+    if (![representations count]) {
+        if (completionBlock) {
+            completionBlock(nil, nil);
+        }
+        return;
+    }
 
     NSUInteger numberOfRepresentations = [representations count];
     NSMutableArray *mutableManagedObjects = [NSMutableArray arrayWithCapacity:numberOfRepresentations];
@@ -284,7 +291,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             
             id relationshipRepresentation = [relationshipRepresentations objectForKey:relationshipName];
             
-            if (!relationshipRepresentation || [relationshipRepresentation isEqual:[NSNull null]]) {
+            if (!relationshipRepresentation || [relationshipRepresentation isEqual:[NSNull null]] || ![relationshipRepresentation count]) {
                 [managedObject setValue:nil forKey:relationshipName];
                 [backingObject setValue:nil forKey:relationshipName];
                 continue;

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -295,10 +295,12 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     
     NSFetchRequest *fetchRequest = [self fetchRequestForObjectIDWithEntity:entity resourceIdentifier:resourceIdentifier];
     
+    [self.backingPersistentStoreCoordinator lock];
     __block NSArray *results = nil;
     [context af_performBlockAndWait:^{
        results = [context executeFetchRequest:fetchRequest error:outError];
     }];
+    [self.backingPersistentStoreCoordinator unlock];
     
     return [results lastObject];
 

--- a/AFIncrementalStore/AFRESTClient+ValueTransforming.h
+++ b/AFIncrementalStore/AFRESTClient+ValueTransforming.h
@@ -1,0 +1,13 @@
+#import <objc/runtime.h>
+#import "AFRESTClient.h"
+
+@interface AFRESTClient (ValueTransforming)
+
++ (NSDictionary *) defaultAttributeTypesToValueTransformers;
+
+- (NSValueTransformer *) valueTransformerForAttributeType:(NSAttributeType)type;
+- (void) setValueTransformer:(NSValueTransformer *)transformer forAttributeType:(NSAttributeType)type;
+
+- (id) valueForObject:(id)object inAttribute:(NSAttributeDescription *)attribute;
+
+@end

--- a/AFIncrementalStore/AFRESTClient+ValueTransforming.m
+++ b/AFIncrementalStore/AFRESTClient+ValueTransforming.m
@@ -1,0 +1,59 @@
+#import "AFRESTClient+ValueTransforming.h"
+
+NSString * const kTypesToValueTransformers = @"-[AFRESTClient(ValueTransforming) typesToValueTransformers]";
+
+@implementation AFRESTClient (ValueTransforming)
+
++ (NSDictionary *) defaultAttributeTypesToValueTransformers {
+
+	return @{
+	
+		@(NSDateAttributeType): [NSValueTransformer valueTransformerForName:@"AFRESTDateTransformer"],
+		
+		@(NSDecimalAttributeType): [NSValueTransformer valueTransformerForName:@"AFRESTDecimalTransformer"]
+	
+	};
+
+}
+
+- (NSMutableDictionary *) typesToValueTransformers {
+
+	NSMutableDictionary *dictionary = objc_getAssociatedObject(self, &kTypesToValueTransformers);
+	if (!dictionary) {
+		dictionary = [[[self class] defaultAttributeTypesToValueTransformers] mutableCopy];
+		objc_setAssociatedObject(self, &kTypesToValueTransformers, dictionary, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}
+	
+	return dictionary;
+
+}
+
+- (NSValueTransformer *) valueTransformerForAttributeType:(NSAttributeType)type {
+
+	return [self typesToValueTransformers][@(type)];
+
+}
+
+- (void) setValueTransformer:(NSValueTransformer *)transformer forAttributeType:(NSAttributeType)type {
+
+	[self typesToValueTransformers][@(type)] = transformer;
+
+}
+
+- (id) valueForObject:(id)object inAttribute:(NSAttributeDescription *)attribute {
+
+	NSAttributeType type = attribute.attributeType;
+	NSValueTransformer *transformer = [self valueTransformerForAttributeType:type];
+	
+	if (!transformer) {
+		return object;
+	}
+
+	id returnedValue = [transformer transformedValue:object];
+	NSCParameterAssert([returnedValue isKindOfClass:[[transformer class] transformedValueClass]]);
+	
+	return returnedValue;
+
+}
+
+@end

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -134,7 +134,7 @@ static NSString * AFPluralizedString(NSString *string) {
     NSMutableDictionary *mutableAttributes = [NSMutableDictionary dictionary];
     [entity.attributesByName enumerateKeysAndObjectsUsingBlock:^(NSString *attributeName, NSAttributeDescription *attribute, BOOL *stop) {
     
-        id value = [mutableAttributes objectForKey:attributeName];
+        id value = [representation objectForKey:attributeName];
         if (value) {
             if (![value isEqual:[NSNull null]]) {
                 [mutableAttributes setValue:[self valueForObject:value inAttribute:attribute] forKey:attributeName];

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import "AFRESTClient.h"
+#import "AFRESTClient+ValueTransforming.h"
 #import "ISO8601DateFormatter.h"
 
 static NSString * AFPluralizedString(NSString *string) {
@@ -110,7 +111,13 @@ static NSString * AFPluralizedString(NSString *string) {
     if (key) {
         id value = [representation valueForKey:key];
         if (value) {
-            return [value description];
+            if ([value isKindOfClass:[NSString class]]) {
+                return (NSString *)value;
+            } else if ([value isKindOfClass:[NSNumber class]]) {
+                return [(NSNumber *)value stringValue];
+            } else {
+                return [value description];
+            }
         }
     }
     
@@ -121,35 +128,21 @@ static NSString * AFPluralizedString(NSString *string) {
                                      ofEntity:(NSEntityDescription *)entity
                                  fromResponse:(NSHTTPURLResponse *)response
 {
-    static ISO8601DateFormatter *_iso8601DateFormatter = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        _iso8601DateFormatter = [[ISO8601DateFormatter alloc] init];
-    });
-    
-    if ([representation isEqual:[NSNull null]]) {
+    if (!representation || [representation isEqual:[NSNull null]])
         return nil;
-    }
     
-    NSMutableDictionary *mutableAttributes = [representation mutableCopy];
-    @autoreleasepool {
-        NSMutableSet *mutableKeys = [NSMutableSet setWithArray:[representation allKeys]];
-        [mutableKeys minusSet:[NSSet setWithArray:[[entity propertiesByName] allKeys]]];
-        [mutableAttributes removeObjectsForKeys:[mutableKeys allObjects]];
-    }
+    NSMutableDictionary *mutableAttributes = [NSMutableDictionary dictionary];
+    [entity.attributesByName enumerateKeysAndObjectsUsingBlock:^(NSString *attributeName, NSAttributeDescription *attribute, BOOL *stop) {
     
-    NSSet *keysWithNestedValues = [mutableAttributes keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
-        return [obj isKindOfClass:[NSArray class]] || [obj isKindOfClass:[NSDictionary class]];
-    }];
-    [mutableAttributes removeObjectsForKeys:[keysWithNestedValues allObjects]];
-    
-    [[entity attributesByName] enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        if ([(NSAttributeDescription *)obj attributeType] == NSDateAttributeType) {
-            id value = [mutableAttributes valueForKey:key];
-            if (value && ![value isEqual:[NSNull null]]) {
-                [mutableAttributes setValue:[_iso8601DateFormatter dateFromString:value] forKey:key];
+        id value = [mutableAttributes objectForKey:attributeName];
+        if (value) {
+            if (![value isEqual:[NSNull null]]) {
+                [mutableAttributes setValue:[self valueForObject:value inAttribute:attribute] forKey:attributeName];
+            } else {
+                [mutableAttributes setValue:value forKey:attributeName];
             }
         }
+        
     }];
     
     return mutableAttributes;

--- a/AFIncrementalStore/AFRESTDateTransformer.h
+++ b/AFIncrementalStore/AFRESTDateTransformer.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface AFRESTDateTransformer : NSValueTransformer
+
+@end

--- a/AFIncrementalStore/AFRESTDateTransformer.m
+++ b/AFIncrementalStore/AFRESTDateTransformer.m
@@ -1,0 +1,40 @@
+#import "AFRESTDateTransformer.h"
+#import "ISO8601DateFormatter.h"
+
+@implementation AFRESTDateTransformer
+
++ (void) load {
+
+	[self setValueTransformer:[self new] forName:NSStringFromClass(self)];
+
+}
+
++ (Class) transformedValueClass {
+
+	return [NSDate class];
+
+}
+
+- (id) transformedValue:(id)value {
+
+	if ([value isKindOfClass:[NSDate class]]) {
+	
+		return value;
+	
+	} else if ([value isKindOfClass:[NSString class]]) {
+	
+		static dispatch_once_t onceToken;
+		static ISO8601DateFormatter *dateFormatter;
+		dispatch_once(&onceToken, ^{
+			dateFormatter = [ISO8601DateFormatter new];
+		});
+		
+		return [dateFormatter dateFromString:(NSString *)value];
+	
+	}
+	
+	return nil;
+
+}
+
+@end

--- a/AFIncrementalStore/AFRESTDecimalTransformer.h
+++ b/AFIncrementalStore/AFRESTDecimalTransformer.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface AFRESTDecimalTransformer : NSValueTransformer
+
+@end

--- a/AFIncrementalStore/AFRESTDecimalTransformer.m
+++ b/AFIncrementalStore/AFRESTDecimalTransformer.m
@@ -1,0 +1,39 @@
+#import "AFRESTDecimalTransformer.h"
+
+@implementation AFRESTDecimalTransformer
+
++ (void) load {
+
+	[self setValueTransformer:[self new] forName:NSStringFromClass(self)];
+
+}
+
++ (Class) transformedValueClass {
+
+	return [NSDecimalNumber class];
+
+}
+
+- (id) transformedValue:(id)value {
+
+	if ([value isKindOfClass:[NSNumber class]]) {
+	
+		//	https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSDecimalNumber_Class/Reference/Reference.html
+	
+		const char * valueType = [value objCType];
+		if (!strcmp(valueType, "d"))
+			return value;
+			
+		return [NSDecimalNumber decimalNumberWithDecimal:[value decimalValue]];
+	
+	} else if ([value isKindOfClass:[NSString class]]) {
+	
+		return [NSDecimalNumber decimalNumberWithString:(NSString *)value];
+	
+	}
+	
+	return nil;
+
+}
+
+@end

--- a/AFIncrementalStore/NSManagedObject+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObject+AFIncrementalStore.h
@@ -4,4 +4,6 @@
 
 @property (readwrite, nonatomic, copy, setter = af_setResourceIdentifier:) NSString *af_resourceIdentifier;
 
+- (BOOL) af_isPermanent;
+
 @end

--- a/AFIncrementalStore/NSManagedObject+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObject+AFIncrementalStore.h
@@ -1,0 +1,7 @@
+#import <CoreData/CoreData.h>
+
+@interface NSManagedObject (AFIncrementalStore)
+
+@property (readwrite, nonatomic, copy, setter = af_setResourceIdentifier:) NSString *af_resourceIdentifier;
+
+@end

--- a/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
@@ -1,0 +1,29 @@
+#import "NSManagedObject+AFIncrementalStore.h"
+#import "AFIncrementalStore.h"
+
+static char kAFResourceIdentifierObjectKey;
+
+@implementation NSManagedObject (AFIncrementalStore)
+@dynamic af_resourceIdentifier;
+
+- (NSString *) af_resourceIdentifier {
+
+    NSString *identifier = (NSString *)objc_getAssociatedObject(self, &kAFResourceIdentifierObjectKey);
+    
+    if (!identifier) {
+        if ([self.objectID.persistentStore isKindOfClass:[AFIncrementalStore class]]) {
+            return [(AFIncrementalStore *)self.objectID.persistentStore referenceObjectForObjectID:self.objectID];
+        }
+    }
+    
+    return identifier;
+    
+}
+
+- (void) af_setResourceIdentifier:(NSString *)resourceIdentifier {
+  
+		objc_setAssociatedObject(self, &kAFResourceIdentifierObjectKey, resourceIdentifier, OBJC_ASSOCIATION_COPY_NONATOMIC);
+		
+}
+
+@end

--- a/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
@@ -29,4 +29,11 @@ static char kAFResourceIdentifierObjectKey;
 		
 }
 
+- (BOOL) af_isPermanent {
+
+	NSManagedObjectID *objectID = self.objectID;
+	return objectID && ![objectID isTemporaryID];
+
+}
+
 @end

--- a/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObject+AFIncrementalStore.m
@@ -12,7 +12,10 @@ static char kAFResourceIdentifierObjectKey;
     
     if (!identifier) {
         if ([self.objectID.persistentStore isKindOfClass:[AFIncrementalStore class]]) {
-            return [(AFIncrementalStore *)self.objectID.persistentStore referenceObjectForObjectID:self.objectID];
+            id referenceObject = [(AFIncrementalStore *)self.objectID.persistentStore referenceObjectForObjectID:self.objectID];
+            if ([referenceObject isKindOfClass:[NSString class]]) {
+                return referenceObject;
+            }
         }
     }
     

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
@@ -1,3 +1,4 @@
+#import <objc/runtime.h>
 #import <CoreData/CoreData.h>
 
 @interface NSManagedObjectContext (AFIncrementalStore)
@@ -7,7 +8,10 @@
 - (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block;
 
 - (void) af_performBlock:(void(^)())block;
-
 - (void) af_performBlockAndWait:(void(^)())block;
+
+- (NSUInteger) af_ignoringCount;
+- (void) af_incrementIgnoringCount;
+- (void) af_decrementIgnoringCount;
 
 @end

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
@@ -1,0 +1,9 @@
+#import <CoreData/CoreData.h>
+
+@interface NSManagedObjectContext (AFIncrementalStore)
+
+- (BOOL) af_isDescendantOfContext:(NSManagedObjectContext *)context;
+
+- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block;
+
+@end

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
@@ -6,4 +6,8 @@
 
 - (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block;
 
+- (void) af_performBlock:(void(^)())block;
+
+- (void) af_performBlockAndWait:(void(^)())block;
+
 @end

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.h
@@ -5,7 +5,7 @@
 
 - (BOOL) af_isDescendantOfContext:(NSManagedObjectContext *)context;
 
-- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block;
+- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(id results, NSError *error))block;
 
 - (void) af_performBlock:(void(^)())block;
 - (void) af_performBlockAndWait:(void(^)())block;

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
@@ -1,5 +1,7 @@
 #import "NSManagedObjectContext+AFIncrementalStore.h"
 
+const void * kIgnoringCount = &kIgnoringCount;
+
 @implementation NSManagedObjectContext (AFIncrementalStore)
 
 - (BOOL) af_isDescendantOfContext:(NSManagedObjectContext *)context {
@@ -66,6 +68,35 @@
 		}
 	
 	}
+
+}
+
+- (NSUInteger) af_ignoringCount {
+
+	return [objc_getAssociatedObject(self, &kIgnoringCount) unsignedIntegerValue];
+
+}
+
+- (void) af_setIgnoringCount:(NSUInteger)count {
+
+	objc_setAssociatedObject(self, &kIgnoringCount, [NSNumber numberWithUnsignedInteger:count], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	
+}
+
+- (void) af_incrementIgnoringCount {
+
+	NSUInteger count = [self af_ignoringCount];
+	
+	[self af_setIgnoringCount:(count + 1)];
+
+}
+
+- (void) af_decrementIgnoringCount {
+
+	NSUInteger count = [self af_ignoringCount];
+	NSCParameterAssert(count);
+	
+	[self af_setIgnoringCount:(count - 1)];
 
 }
 

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
@@ -31,4 +31,42 @@
 
 }
 
+- (void) af_performBlock:(void(^)())block {
+
+	switch (self.concurrencyType) {
+	
+		case NSMainQueueConcurrencyType:
+		case NSPrivateQueueConcurrencyType: {
+			[self performBlock:block];
+			break;
+		}
+		
+		case NSConfinementConcurrencyType: {
+			block();
+			break;
+		}
+	
+	}
+	
+}
+
+- (void) af_performBlockAndWait:(void(^)())block {
+
+	switch (self.concurrencyType) {
+	
+		case NSMainQueueConcurrencyType:
+		case NSPrivateQueueConcurrencyType: {
+			[self performBlockAndWait:block];
+			break;
+		}
+		
+		case NSConfinementConcurrencyType: {
+			block();
+			break;
+		}
+	
+	}
+
+}
+
 @end

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
@@ -16,7 +16,7 @@ const void * kIgnoringCount = &kIgnoringCount;
 
 }
 
-- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block {
+- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(id results, NSError *error))block {
 
 	NSCParameterAssert(fetchRequest);
 	NSCParameterAssert(block);
@@ -24,7 +24,7 @@ const void * kIgnoringCount = &kIgnoringCount;
 	[self performBlock:^{
 	
 		NSError *error = nil;
-		NSArray *results = [self executeFetchRequest:fetchRequest error:&error];
+		id results = [self executeFetchRequest:fetchRequest error:&error];
 		
 		if (block)
 			block(results, error);

--- a/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
+++ b/AFIncrementalStore/NSManagedObjectContext+AFIncrementalStore.m
@@ -1,0 +1,34 @@
+#import "NSManagedObjectContext+AFIncrementalStore.h"
+
+@implementation NSManagedObjectContext (AFIncrementalStore)
+
+- (BOOL) af_isDescendantOfContext:(NSManagedObjectContext *)context {
+
+	if (self == context)
+		return YES;
+	
+	if (!self.parentContext)
+		return NO;
+	
+	return [self.parentContext af_isDescendantOfContext:context];
+
+}
+
+- (void) af_executeFetchRequest:(NSFetchRequest *)fetchRequest usingBlock:(void(^)(NSArray *results, NSError *error))block {
+
+	NSCParameterAssert(fetchRequest);
+	NSCParameterAssert(block);
+	
+	[self performBlock:^{
+	
+		NSError *error = nil;
+		NSArray *results = [self executeFetchRequest:fetchRequest error:&error];
+		
+		if (block)
+			block(results, error);
+		
+	}];
+
+}
+
+@end


### PR DESCRIPTION
Request based on `develop` branch with previous request https://github.com/AFNetworking/AFIncrementalStore/pull/66.
- Fixes an issue where loading remote relationships at least once creates a phantom listener on saves against the ephemeral context used to save information into the requesting context.
- Initial support for value transformers plugged against attribute types implemented as a category on AFHTTPClient.
- Fixes semantics regarding attribute transforming; removes some code and adds some code in `-AFRESTClient attributesForRepresentation:ofEntity:fromResponse:`.
