### PR TITLE
Ignore the null (nil) value in the fetched relationship and relationship is optional

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -249,11 +249,13 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
         NSDictionary *relationshipRepresentations = [self.HTTPClient representationsForRelationshipsFromRepresentation:representation ofEntity:entity fromResponse:response];
         for (NSString *relationshipName in relationshipRepresentations) {
             NSRelationshipDescription *relationship = [[entity relationshipsByName] valueForKey:relationshipName];
-            if (!relationship) {
+            id relationshipValue = [relationshipRepresentations objectForKey:relationshipName];
+            if (!relationship ||
+                (relationship.isOptional && (!relationshipValue || relationshipValue == [NSNull null]))) {
                 continue;
             }
             
-            [self insertOrUpdateObjectsFromRepresentations:[relationshipRepresentations objectForKey:relationshipName] ofEntity:relationship.destinationEntity fromResponse:response withContext:context error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
+            [self insertOrUpdateObjectsFromRepresentations:relationshipValue ofEntity:relationship.destinationEntity fromResponse:response withContext:context error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
                 if ([relationship isToMany]) {
                     if ([relationship isOrdered]) {
                         [managedObject setValue:[NSOrderedSet orderedSetWithArray:managedObjects] forKey:relationship.name];


### PR DESCRIPTION
The service I use sometime return the nil in the returned JSON. So I configure the Managed Object Model that relationship to optional.
BTW AFIS will crash in

```
- (void)insertOrUpdateObjectsFromRepresentations:
                                        ofEntity:
                                    fromResponse:
                                     withContext:
                                           error:
                                 completionBlock:
```

methods with unrecognized selector exception on line 

```
    NSMutableArray *mutableManagedObjects = [NSMutableArray arrayWithCapacity:[representationOrArrayOfRepresentations count]];
```

because the representationOrArrayOfRepresentations is [NSNull null]
