### PR TITLE
changed the podspec to include the dependency of ISO8601DateFormatter

### DIFF
--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.dependency 'AFNetworking', '>= 0.9.0'
+  s.dependency 'ISO8601DateFormatter'
 end


### PR DESCRIPTION
After addition of ISO8601DateFormatter submodule podspec wasn't updated to include it as a dependency leading to build failure
