### PR TITLE
Add operation argument to representationOrArrayOfRepresentationsFromResp...

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -122,10 +122,12 @@
  @discussion For example, if `GET /users` returned an `NSDictionary` with an array of users keyed on `"users"`, this method would return the keyed array. Conversely, if `GET /users/123` returned a dictionary with all of the atributes of the requested user, this method would simply return that dictionary.
 
  @param responseObject The response object returned from the server.
+ @param operation The request operation used for the HTTP request.
  
  @return An `NSDictionary` or an `NSArray` of `NSDictionaries` containing the resource representations.
  */
-- (id)representationOrArrayOfRepresentationsFromResponseObject:(id)responseObject;
+- (id)representationOrArrayOfRepresentationsFromResponseObject:(id)responseObject
+                                                     operation:(AFHTTPRequestOperation *)operation;
 
 /**
  Returns an `NSDictionary` containing the representations of associated objects found within the representation of a response object, keyed by their relationship name.

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -304,7 +304,8 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     NSURLRequest *request = [self.HTTPClient requestForFetchRequest:fetchRequest withContext:context];
     if ([request URL]) {
         AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-            id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
+            id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject
+                                                                                                                        operation:operation];
     
             NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
             childContext.parentContext = context;
@@ -530,7 +531,8 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             }];
             
             AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
-                id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
+                id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject
+                                                                                                                            operation:operation];
                 
                 NSArray *representations = nil;
                 if ([representationOrArrayOfRepresentations isKindOfClass:[NSArray class]]) {

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -52,7 +52,8 @@ static NSString * AFPluralizedString(NSString *string) {
 
 #pragma mark Read Methods
 
-- (id)representationOrArrayOfRepresentationsFromResponseObject:(id)responseObject {
+- (id)representationOrArrayOfRepresentationsFromResponseObject:(id)responseObject
+                                                     operation:(AFHTTPRequestOperation *)operation {
     if ([responseObject isKindOfClass:[NSArray class]]) {
         return responseObject;
     } else if ([responseObject isKindOfClass:[NSDictionary class]]) {


### PR DESCRIPTION
I believe that this would help in allowing people to work around APIs that don't always return consistent response structures between calls. For example, most of the calls to the API I'm currently interacting with work fine with the existing implementation of representationOrArrayOfRepresentationsFromResponseObject: 

However, one call returns a response in the following format. (I only want what's in the "matches" array)

``` json
{
  "query": {
    "limit": numberMaximum number of results returned,
    "offset": numberOffset requested in query (zero based),
    "active_after": numberResults include contacts in at least one email dated after a given time,
    "active_before": numberResults include contacts in at least one email dated before a given time,
    "search": stringResults included contacts whose name of address match this search term
  },
  "matches": [
    {
      "email": stringemail address of contact,
      "count": numbernumber of messages exchanged with this contact,
      "name": stringName associated to contact,
      "thumbnail": stringURL pointing to Gravatar image associated to contact's email address, if applicable
    },
    ...
  ]
}
```

In my particular case, I could probably rely on analyzing the response object alone, but using the operation and attached request seems like it may be a bit cleaner and more flexible. What do you think? Any other ideas?
