### PR TITLE
Removed unused wrapping of representationOrArrayOfRepresentations in Array

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -532,13 +532,6 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
             AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
                 id representationOrArrayOfRepresentations = [self.HTTPClient representationOrArrayOfRepresentationsFromResponseObject:responseObject];
                 
-                NSArray *representations = nil;
-                if ([representationOrArrayOfRepresentations isKindOfClass:[NSArray class]]) {
-                    representations = representationOrArrayOfRepresentations;
-                } else {
-                    representations = [NSArray arrayWithObject:representationOrArrayOfRepresentations];
-                }
-                
                 [childContext performBlock:^{
                     [self insertOrUpdateObjectsFromRepresentations:representationOrArrayOfRepresentations ofEntity:relationship.destinationEntity fromResponse:operation.response withContext:childContext error:error completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
                         NSManagedObject *managedObject = [childContext objectWithID:objectID];


### PR DESCRIPTION
in _newValueForRelationship:forObjectWithID:withContext:error:_, there seems to be some left-over code from before the switch to using the recursive function _insertOrUpdateObjectsFromRepresentations:_. The 'id' object called representationOrArrayOfRepresentations is being conditionally wrapped in an NSArray *representations, if it wasn't already an NSArray itself. 

This variable is then never used, because that same check happens within that other method. I removed the unused code in the attached pull request.
