### PR TITLE
Add in a rule to properly pluralize strings that end with Y when Y is not proceeded by a vowel.

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -24,8 +24,11 @@
 #import "ISO8601DateFormatter.h"
 
 static NSString * AFPluralizedString(NSString *string) {
+    NSCharacterSet *vowels = [NSCharacterSet characterSetWithCharactersInString:@"aeiou"];
     if ([string hasSuffix:@"ss"] || [string hasSuffix:@"se"] || [string hasSuffix:@"sh"] || [string hasSuffix:@"ch"]) {
         return [[string stringByAppendingString:@"es"] lowercaseString];
+    } else if ([string hasSuffix:@"y"] && ![vowels characterIsMember:[string characterAtIndex:([string length] - 2)]]) {
+        return [[[string substringWithRange:NSMakeRange(0, [string length] - 1)] stringByAppendingString:@"ies"] lowercaseString];
     } else {
         return [[string stringByAppendingString:@"s"] lowercaseString];
     }


### PR DESCRIPTION
An example that matches is 'Property - Properties' or 'Library -
Libraries'. What won't match is 'Boy - Boys', or 'Valley - Valleys'

This function seems like it might start to get ugly very soon. Possibly
an AFStringInflector class (or NSString Category) could be a solution?
