### PR TITLE
Issues with last modified date resulting in unchanged data being re-downloaded

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -497,6 +497,8 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                     NSManagedObjectID *backingObjectID = [self objectIDForBackingObjectForEntity:[objectID entity] withResourceIdentifier:[self referenceObjectForObjectID:objectID]];
                     NSManagedObject *backingObject = [[self backingManagedObjectContext] existingObjectWithID:backingObjectID error:nil];
                     [backingObject setValuesForKeysWithDictionary:mutableAttributeValues];
+                    NSDate *lastModified = AFLastModifiedDateFromHTTPHeaders([operation.response allHeaderFields]);
+                    [backingObject setValue:lastModified forKey:kAFIncrementalStoreLastModifiedAttributeName];
                     
                     [childContext performBlock:^{
                         if (![[self backingManagedObjectContext] save:error] || ![childContext save:error]) {

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -457,7 +457,9 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
     fetchRequest.resultType = NSDictionaryResultType;
     fetchRequest.fetchLimit = 1;
     fetchRequest.includesSubentities = NO;
-    fetchRequest.propertiesToFetch = [[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allKeys];
+    NSMutableArray *propertiesToFetch = [NSMutableArray arrayWithArray:[[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allKeys]];
+    [propertiesToFetch addObject:kAFIncrementalStoreLastModifiedAttributeName];
+    fetchRequest.propertiesToFetch = propertiesToFetch;
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"%K = %@", kAFIncrementalStoreResourceIdentifierAttributeName, [self referenceObjectForObjectID:objectID]];
     
     NSArray *results = [[self backingManagedObjectContext] executeFetchRequest:fetchRequest error:error];
@@ -483,6 +485,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                     
                     NSMutableDictionary *mutableAttributeValues = [attributeValues mutableCopy];
                     [mutableAttributeValues addEntriesFromDictionary:[self.HTTPClient attributesForRepresentation:representation ofEntity:managedObject.entity fromResponse:operation.response]];
+                    [mutableAttributeValues removeObjectForKey:kAFIncrementalStoreLastModifiedAttributeName];                    
                     [managedObject setValuesForKeysWithDictionary:mutableAttributeValues];
                     
                     NSManagedObjectID *backingObjectID = [self objectIDForBackingObjectForEntity:[objectID entity] withResourceIdentifier:[self referenceObjectForObjectID:objectID]];


### PR DESCRIPTION
Could someone comment on why AFIS is using ISO8601 to parse the last modified date? I've changed this to support HTTP1.1 RFC 1123 format and fixed a couple of related bugs:

1) Last modified date not being retrieved from backing store
2) HTTP 1.1 last modified date not being parsed correctly
3) Last modified date not being updated in newValuesForObjectWithID
