### PR TITLE
Added AFFetchSaveManager class to observe notifications and fire appropriate blocks

### DIFF
--- a/AFIncrementalStore/AFFetchSaveManager.h
+++ b/AFIncrementalStore/AFFetchSaveManager.h
@@ -8,8 +8,8 @@
 
 @class AFHTTPRequestOperation;
 
-typedef void (^AFIncrementalStoreFetchCompletionBlock)(NSFetchRequest *fetchRequest, AFHTTPRequestOperation *operation, NSArray *fetchedObjectIDs);
-typedef void (^AFIncrementalStoreSaveCompletionBlock)(NSSaveChangesRequest *saveChangesRequest, AFHTTPRequestOperation *operation, NSArray *insertedObjectIDs, NSArray *updatedObjectIDs, NSArray *deletedObjectIDs);
+typedef void (^AFIncrementalStoreFetchCompletionBlock)(NSFetchRequest *fetchRequest, AFHTTPRequestOperation *operation, NSArray *fetchedObjects);
+typedef void (^AFIncrementalStoreSaveCompletionBlock)(NSSaveChangesRequest *saveChangesRequest, AFHTTPRequestOperation *operation, NSArray *insertedObjects, NSArray *updatedObjects, NSArray *deletedObjectIDs);
 
 @interface AFFetchSaveManager : NSObject
 

--- a/AFIncrementalStore/AFFetchSaveManager.h
+++ b/AFIncrementalStore/AFFetchSaveManager.h
@@ -1,0 +1,49 @@
+//
+//  AFFetchSaveManager.h
+//  Sharely
+//
+//  Created by Adam Price on 10/26/12.
+//  Copyright (c) 2012 Fuzz Productions. All rights reserved.
+//
+
+@class AFHTTPRequestOperation;
+
+typedef void (^AFIncrementalStoreFetchCompletionBlock)(NSFetchRequest *fetchRequest, AFHTTPRequestOperation *operation, NSArray *fetchedObjectIDs);
+typedef void (^AFIncrementalStoreSaveCompletionBlock)(NSSaveChangesRequest *saveChangesRequest, AFHTTPRequestOperation *operation, NSArray *insertedObjectIDs, NSArray *updatedObjectIDs, NSArray *deletedObjectIDs);
+
+@interface AFFetchSaveManager : NSObject
+
+/**
+ `AFFetchSaveManager` is a class designed to manage executing NSFetchRequests with completion blocks and NSManagedObjectContext saves with completion blocks. There is no need to create an instance of this class; the class itself is the observer for notifications and the only public methods are class methods.
+ 
+ ## Description
+ 
+ There are only two class methods with which to interface with AFFetchSaveManager. An exception will be raised if you call these methods without a context.
+ 
+ The completion and failure blocks will be associated with the corresponding NSFetchRequest or NSSaveChangesRequest that are executed by AFIncrementalStore. 
+ AFFetchSaveManager acts as a global observer of AFIncrementalStore's NSNotifications, and will execute the appropriate completion block when it gets the corresponding 
+ didFetchRemoteValues: or didSaveRemoteValues: notification.
+ */
+
++ (BOOL)saveContext:(NSManagedObjectContext *)context
+			  error:(NSError *__autoreleasing*)error
+		 completion:(AFIncrementalStoreSaveCompletionBlock)completionBlock;
+
++ (NSArray *)executeFetchRequest:(NSFetchRequest *)fetchRequest
+						 context:(NSManagedObjectContext *)context
+						   error:(NSError *__autoreleasing*)error
+					  completion:(AFIncrementalStoreFetchCompletionBlock)completionBlock;
+
+///-----------------------------------------
+/// @name ManagedObjectContext userInfo keys
+///-----------------------------------------
+
+/**
+ A key in the `userInfo` dictionary of a NSManagedObjectContext, set by AFFetchSaveManager.
+ The corresponding value is a unique `requestIdentifier` key that is generated in each of AFFetchSaveManager's class methods and used as a key for the pending completion block
+ of that NSPersistentStoreRequest. This key is immediately removed from the `userInfo` dictionary and attached to the appropriate NSFetchRequest or NSSaveChangesRequest in the
+ executeRequest:withContext:error method of AFIncrementalStore.
+ */
+extern NSString * const AFFetchSaveManagerPersistentStoreRequestIdentifierKey;
+
+@end

--- a/AFIncrementalStore/AFFetchSaveManager.m
+++ b/AFIncrementalStore/AFFetchSaveManager.m
@@ -133,7 +133,7 @@ static NSMutableDictionary *_saveRequestBlockDictionary = nil;
 				couldNotFindValidCompletionBlock = YES;
 			else
 			{
-				NSArray *tmpFetchedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreFetchedObjectIDsKey];
+				NSArray *tmpFetchedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreFetchedObjectsKey];
 				if (tmpFetchCompletionBlock)
 					tmpFetchCompletionBlock((NSFetchRequest *)tmpPersistentStoreRequest, tmpOperation, tmpFetchedObjects);
 			}
@@ -145,8 +145,8 @@ static NSMutableDictionary *_saveRequestBlockDictionary = nil;
 				couldNotFindValidCompletionBlock = YES;
 			else
 			{
-				NSArray *tmpInsertedObjects =  [inNotification.userInfo objectForKey:AFIncrementalStoreInsertedObjectIDsKey];
-				NSArray *tmpUpdatedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreUpdatedObjectIDsKey];
+				NSArray *tmpInsertedObjects =  [inNotification.userInfo objectForKey:AFIncrementalStoreInsertedObjectsKey];
+				NSArray *tmpUpdatedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreUpdatedObjectsKey];
 				NSArray *tmpDeletedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreDeletedObjectIDsKey];
 				if (tmpSaveCompletionBlock)
 					tmpSaveCompletionBlock((NSSaveChangesRequest *)tmpPersistentStoreRequest, tmpOperation, tmpInsertedObjects, tmpUpdatedObjects, tmpDeletedObjects);

--- a/AFIncrementalStore/AFFetchSaveManager.m
+++ b/AFIncrementalStore/AFFetchSaveManager.m
@@ -1,0 +1,163 @@
+//
+//  AFFetchSaveManager.m
+//  Sharely
+//
+//  Created by Adam Price on 10/26/12.
+//  Copyright (c) 2012 Fuzz Productions. All rights reserved.
+//
+
+#import <CoreData/CoreData.h>
+#import "AFFetchSaveManager.h"
+#import "AFIncrementalStore.h"
+
+NSString * const AFFetchSaveManagerPersistentStoreRequestIdentifierKey = @"AFFetchSaveManagerPersistentStoreRequestIdentifierKey";
+
+static NSMutableDictionary *_fetchRequestBlockDictionary = nil;
+static NSMutableDictionary *_saveRequestBlockDictionary = nil;
+
+@implementation AFFetchSaveManager
+
++ (void)setupObserver
+{
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken,^
+	{
+		[[NSNotificationCenter defaultCenter] addObserver:[self class] selector:@selector(willFetchRemoteValues:) name:AFIncrementalStoreContextWillFetchRemoteValues object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:[self class] selector:@selector(didFetchRemoteValues:) name:AFIncrementalStoreContextDidFetchRemoteValues object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:[self class] selector:@selector(willSaveRemoteValues:) name:AFIncrementalStoreContextWillSaveRemoteValues object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:[self class] selector:@selector(didSaveRemoteValues:) name:AFIncrementalStoreContextDidSaveRemoteValues object:nil];
+	});
+}
+
+#pragma mark -
+#pragma mark NSManagedObjectContext public class methods
+
++ (NSArray *)executeFetchRequest:(NSFetchRequest *)fetchRequest
+					context:(NSManagedObjectContext *)context
+					  error:(NSError *__autoreleasing*)error
+				 completion:(AFIncrementalStoreFetchCompletionBlock)completionBlock
+{
+	NSParameterAssert(context);
+	
+	[[self class] setupObserver];
+	
+	if (completionBlock) {
+		NSString *requestIdentifier = [[NSProcessInfo processInfo] globallyUniqueString];
+		
+		[context.userInfo setObject:requestIdentifier forKey:AFFetchSaveManagerPersistentStoreRequestIdentifierKey];
+
+		[[[self class] fetchRequestBlockDictionary] setObject:completionBlock forKey:requestIdentifier];
+	}
+	
+	return [context executeFetchRequest:fetchRequest error:error];
+}
+
++ (BOOL)saveContext:(NSManagedObjectContext *)context
+			  error:(NSError *__autoreleasing*)error
+		 completion:(AFIncrementalStoreSaveCompletionBlock)completionBlock
+{
+	NSParameterAssert(context);
+	
+	[[self class] setupObserver];
+	
+	if (completionBlock) {
+		NSString *requestIdentifier = [[NSProcessInfo processInfo] globallyUniqueString];
+		
+		[context.userInfo setObject:requestIdentifier forKey:AFFetchSaveManagerPersistentStoreRequestIdentifierKey];
+		
+		[[[self class] saveRequestBlockDictionary] setObject:completionBlock forKey:requestIdentifier];
+	}
+	
+	return [context save:error];
+}
+
+#pragma mark -
+#pragma mark Private Getter Methods
+
++ (NSMutableDictionary *)fetchRequestBlockDictionary
+{
+	if (!_fetchRequestBlockDictionary)
+		_fetchRequestBlockDictionary = [[NSMutableDictionary alloc] init];
+	return _fetchRequestBlockDictionary;
+}
+
++ (NSMutableDictionary *)saveRequestBlockDictionary
+{
+	if (!_saveRequestBlockDictionary)
+		_saveRequestBlockDictionary = [[NSMutableDictionary alloc] init];
+	return _saveRequestBlockDictionary;
+}
+
+#pragma mark -
+#pragma mark NSNotifications
+
++ (void)willFetchRemoteValues:(NSNotification *)inNotification
+{
+	
+}
+
++ (void)didFetchRemoteValues:(NSNotification *)inNotification
+{
+	[[self class] executeCompletionBlockWithNotification:inNotification];
+}
+
++ (void)willSaveRemoteValues:(NSNotification *)inNotification
+{
+
+}
+
++ (void)didSaveRemoteValues:(NSNotification *)inNotification
+{
+	[[self class] executeCompletionBlockWithNotification:inNotification];
+}
+
+#pragma mark -
+#pragma mark Private block handler functions
+
++ (void)executeCompletionBlockWithNotification:(NSNotification *)inNotification
+{
+	BOOL couldNotFindValidCompletionBlock = NO;
+	
+	NSPersistentStoreRequest *tmpPersistentStoreRequest = [inNotification.userInfo objectForKey:AFIncrementalStorePersistentStoreRequestKey];
+	AFHTTPRequestOperation *tmpOperation = [inNotification.userInfo objectForKey:AFIncrementalStoreRequestOperationKey];
+	if (tmpPersistentStoreRequest && tmpOperation)
+	{
+		NSString *requestIdentifier = [tmpPersistentStoreRequest af_requestIdentifier];
+		if (!requestIdentifier || requestIdentifier.length == 0)
+			return;
+		
+		if (tmpPersistentStoreRequest.requestType == NSFetchRequestType)
+		{
+			AFIncrementalStoreFetchCompletionBlock tmpFetchCompletionBlock = [[[self class] fetchRequestBlockDictionary] objectForKey:requestIdentifier];
+			if (!tmpFetchCompletionBlock)
+				couldNotFindValidCompletionBlock = YES;
+			else
+			{
+				NSArray *tmpFetchedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreFetchedObjectIDsKey];
+				if (tmpFetchCompletionBlock)
+					tmpFetchCompletionBlock((NSFetchRequest *)tmpPersistentStoreRequest, tmpOperation, tmpFetchedObjects);
+			}
+		}
+		else
+		{
+			AFIncrementalStoreSaveCompletionBlock tmpSaveCompletionBlock = [[[self class] saveRequestBlockDictionary] objectForKey:requestIdentifier];
+			if (!tmpSaveCompletionBlock)
+				couldNotFindValidCompletionBlock = YES;
+			else
+			{
+				NSArray *tmpInsertedObjects =  [inNotification.userInfo objectForKey:AFIncrementalStoreInsertedObjectIDsKey];
+				NSArray *tmpUpdatedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreUpdatedObjectIDsKey];
+				NSArray *tmpDeletedObjects = [inNotification.userInfo objectForKey:AFIncrementalStoreDeletedObjectIDsKey];
+				if (tmpSaveCompletionBlock)
+					tmpSaveCompletionBlock((NSSaveChangesRequest *)tmpPersistentStoreRequest, tmpOperation, tmpInsertedObjects, tmpUpdatedObjects, tmpDeletedObjects);
+			}
+		}
+	}
+	else
+		couldNotFindValidCompletionBlock = YES;
+	
+	if (couldNotFindValidCompletionBlock)
+		NSLog(@"Could Not Find Valid Completion Block");
+}
+
+@end

--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -23,6 +23,34 @@
 #import <CoreData/CoreData.h>
 #import "AFNetworking.h"
 
+#import <objc/runtime.h>
+
+@interface NSPersistentStoreRequest (_AFIncrementalStore)
+
+/**
+ A property set by AFIncrementalStore to uniquely identify a NSFetchRequest or NSSaveChanges request, in order for the AFFetchSaveManager class to correctly identify it via NSNotification, and subsequently fire the appropriate completion block for that request. 
+ 
+ @discussion If there is a completion block associated with the NSPersistentStoreRequest, AFFetchSaveManager will have generated this unique identifier upon first dispatch of the request and conveys it to the AFIncrementalStore by attaching it to the `userInfo` dictionary of the NSManagedObjectContext.
+ */
+@property (readwrite, nonatomic, copy, setter = af_setRequestIdentifier:) NSString *af_requestIdentifier;
+
+@end
+
+static char kAFRequestIdentifierObjectKey;
+
+@implementation NSPersistentStoreRequest (_AFIncrementalStore)
+@dynamic af_requestIdentifier;
+
+- (NSString *)af_requestIdentifier {
+	return (NSString *)objc_getAssociatedObject(self, &kAFRequestIdentifierObjectKey);
+}
+
+- (void)af_setRequestIdentifier:(NSString *)requestIdentifier {
+	objc_setAssociatedObject(self, &kAFRequestIdentifierObjectKey, requestIdentifier, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+@end
+
 @protocol AFIncrementalStoreDelegate;
 @protocol AFIncrementalStoreHTTPClient;
 
@@ -317,4 +345,33 @@ extern NSString * const AFIncrementalStoreRequestOperationKey;
 /**
  A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
  The corresponding value is an `NSPersistentStoreRequest` object representing the associated fetch or save request. */
+
 extern NSString * const AFIncrementalStorePersistentStoreRequestKey;
+
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is a NSArray containing the permament object ID's associated with the fetched objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ */
+
+extern NSString * const AFIncrementalStoreFetchedObjectIDsKey;
+
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is a NSArray containing the permament object ID's associated with the inserted objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ */
+
+extern NSString * const AFIncrementalStoreInsertedObjectIDsKey;
+
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is a NSArray containing the permament object ID's associated with the updated objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ */
+
+extern NSString * const AFIncrementalStoreUpdatedObjectIDsKey;
+
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is a NSArray containing the permament object ID's associated with the deleted objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ */
+
+extern NSString * const AFIncrementalStoreDeletedObjectIDsKey;

--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -349,28 +349,28 @@ extern NSString * const AFIncrementalStoreRequestOperationKey;
 extern NSString * const AFIncrementalStorePersistentStoreRequestKey;
 
 /**
- A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
- The corresponding value is a NSArray containing the permament object ID's associated with the fetched objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is an `NSArray` object containing the fetched objects, in the context in which they were requested.
  */
 
-extern NSString * const AFIncrementalStoreFetchedObjectIDsKey;
+extern NSString * const AFIncrementalStoreFetchedObjectsKey;
 
 /**
- A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
- The corresponding value is a NSArray containing the permament object ID's associated with the inserted objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextDidSaveRemoteValues` notification.
+ The corresponding value is an `NSArray` object containing the inserted objects, in the context in which they were requested.
  */
 
-extern NSString * const AFIncrementalStoreInsertedObjectIDsKey;
+extern NSString * const AFIncrementalStoreInsertedObjectsKey;
 
 /**
- A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
- The corresponding value is a NSArray containing the permament object ID's associated with the updated objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextDidSaveRemoteValues` notification.
+ The corresponding value is an `NSArray` object containing the updated objects, in the context in which they were requested. 
  */
 
-extern NSString * const AFIncrementalStoreUpdatedObjectIDsKey;
+extern NSString * const AFIncrementalStoreUpdatedObjectsKey;
 
 /**
- A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillSaveRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
  The corresponding value is a NSArray containing the permament object ID's associated with the deleted objects from the originating managed object context. The object ID's are included in the NSNotification because unlike the NSManagedObjects themselves, the IDs are thread-safe.
  */
 

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -460,7 +460,7 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 				
 				[context performBlockAndWait:^{
 					NSManagedObject *contextUpdatedObj = [context existingObjectWithID:updatedObject.objectID error:NULL];
-					[insertedObjects addObject:contextUpdatedObj];
+					[updatedObjects addObject:contextUpdatedObj];
 				}];
             } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                 NSLog(@"Update Error: %@", error);


### PR DESCRIPTION
In response to some of the feedback in Pull Request #77, I created a manager class as a way to execute fetch requests or save requests, listen for the didFetchRemoteValues: and didSaveRemoteValues: notifications, and fire the appropriate completion blocks associated with that fetch or save request.

Let me know if you have any thoughts on this as a potential improvement on the current notification-based design. It's been working well for me so far.
