### PR TITLE
Include fetched objects in the DidFetchRemoteValues notification.

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -318,3 +318,8 @@ extern NSString * const AFIncrementalStoreRequestOperationKey;
  A key in the `userInfo` dictionary in a `AFIncrementalStoreContextWillFetchRemoteValues` or `AFIncrementalStoreContextDidFetchRemoteValues` notification.
  The corresponding value is an `NSPersistentStoreRequest` object representing the associated fetch or save request. */
 extern NSString * const AFIncrementalStorePersistentStoreRequestKey;
+
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextDidFetchRemoteValues` notification.
+ The corresponding value is an `NSArray` object containing the fetched objects, in the context in which they were requested. */
+extern NSString * const AFIncrementalStoreFetchedObjectsKey;

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -34,6 +34,7 @@ NSString * const AFIncrementalStoreContextDidFetchRemoteValues = @"AFIncremental
 NSString * const AFIncrementalStoreContextDidSaveRemoteValues = @"AFIncrementalStoreContextDidSaveRemoteValues";
 NSString * const AFIncrementalStoreRequestOperationKey = @"AFIncrementalStoreRequestOperation";
 NSString * const AFIncrementalStorePersistentStoreRequestKey = @"AFIncrementalStorePersistentStoreRequest";
+NSString * const AFIncrementalStoreFetchedObjectsKey = @"AFIncrementalStoreFetchedObjects";
 
 static NSString * const kAFIncrementalStoreResourceIdentifierAttributeName = @"__af_resourceIdentifier";
 static NSString * const kAFIncrementalStoreLastModifiedAttributeName = @"__af_lastModified";
@@ -108,12 +109,16 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
 - (void)notifyManagedObjectContext:(NSManagedObjectContext *)context
              aboutRequestOperation:(AFHTTPRequestOperation *)operation
                    forFetchRequest:(NSFetchRequest *)fetchRequest
+                    fetchedObjects:(NSArray *)fetchedObjects
 {
     NSString *notificationName = [operation isFinished] ? AFIncrementalStoreContextDidFetchRemoteValues : AFIncrementalStoreContextWillFetchRemoteValues;
     
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     [userInfo setObject:operation forKey:AFIncrementalStoreRequestOperationKey];
     [userInfo setObject:fetchRequest forKey:AFIncrementalStorePersistentStoreRequestKey];
+    if (fetchedObjects) {
+        [userInfo setObject:fetchedObjects forKey:AFIncrementalStoreFetchedObjectsKey];
+    }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:context userInfo:userInfo];
 }
@@ -315,18 +320,25 @@ static NSDate * AFLastModifiedDateFromHTTPHeaders(NSDictionary *headers) {
                     if (![[self backingManagedObjectContext] save:error] || ![childContext save:error]) {
                         NSLog(@"Error: %@", *error);
                     }
+                    
+                    NSMutableArray *objectsInContext = [NSMutableArray new];
+                    [context performBlockAndWait:^{
+                        for (NSManagedObject *obj in managedObjects) {
+                            NSManagedObject *contextObj = [context existingObjectWithID:obj.objectID error:NULL];
+                        }
+                    }];
+                    [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest fetchedObjects:managedObjects];
                 }];
                 
-                [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest];
             }];
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             NSLog(@"Error: %@", error);
-            [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest];
+            [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest fetchedObjects:nil];
         }];
         
         operation.successCallbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
         
-        [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest];
+        [self notifyManagedObjectContext:context aboutRequestOperation:operation forFetchRequest:fetchRequest fetchedObjects:nil];
         [self.HTTPClient enqueueHTTPRequestOperation:operation];
     }
     


### PR DESCRIPTION
This lets the client associate fetched objects with the fetch request that triggered the remote fetch.

Caveat: the notification currently includes _all_ fetched objects, including any nested objects. We should probably make it return only the root fetched objects, so that the objects stored under this key
are directly analogous to those returned synchronously by the `-executeFetchRequest:error:` method.
