### PR TITLE
Fixed a typo in AFIncrementalStore.m

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -159,7 +159,7 @@ inline NSString * AFResourceIdentifierFromReferenceObject(id referenceObject) {
     }
     
     NSManagedObjectID *objectID = nil;
-    NSMutableDictionary *objectIDsByResourceIdentifier = [_registeredObjectIDsByEntityNameAndNestedResourceIdentifier objectForKey:objectID.entity.name];
+    NSMutableDictionary *objectIDsByResourceIdentifier = [_registeredObjectIDsByEntityNameAndNestedResourceIdentifier objectForKey:entity.name];
     if (objectIDsByResourceIdentifier) {
         objectID = [objectIDsByResourceIdentifier objectForKey:resourceIdentifier];
     }


### PR DESCRIPTION
Fixed what I'm 90% sure is a typo.

You've set `objectID` to nil, so `objectID.entity.name` will also be nil. I'm pretty sure this should be `entity.name`.

I noticed this while reading through the code trying to understand how it deals with object ids, so I can't attest to a problem caused by this or if this change will break anything. Not the most helpful, I know, but I just wanted to call attention to this somewhere.
