### PR TITLE
Fix empty NSSaveChangesRequest in `AFIncrementalStoreContextDidSaveRemoteValues`

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -524,10 +524,12 @@ inline NSString * AFResourceIdentifierFromReferenceObject(id referenceObject) {
         }
     }
     
-    [self notifyManagedObjectContext:context aboutRequestOperations:mutableOperations forSaveChangesRequest:saveChangesRequest];
+    NSSaveChangesRequest *saveChangesRequestCopy = [[NSSaveChangesRequest alloc] initWithInsertedObjects:[saveChangesRequest.insertedObjects copy] updatedObjects:[saveChangesRequest.updatedObjects copy] deletedObjects:[saveChangesRequest.deletedObjects copy] lockedObjects:[saveChangesRequest.lockedObjects copy]];
+    
+    [self notifyManagedObjectContext:context aboutRequestOperations:mutableOperations forSaveChangesRequest:saveChangesRequestCopy];
 
     [self.HTTPClient enqueueBatchOfHTTPRequestOperations:mutableOperations progressBlock:nil completionBlock:^(NSArray *operations) {
-        [self notifyManagedObjectContext:context aboutRequestOperations:operations forSaveChangesRequest:saveChangesRequest];
+        [self notifyManagedObjectContext:context aboutRequestOperations:operations forSaveChangesRequest:saveChangesRequestCopy];
     }];
     
     return [NSArray array];


### PR DESCRIPTION
The original instance of NSSaveChangesRequest was passed to both
`AFIncrementalStoreContextWillSaveRemoteValues` and
`AFIncrementalStoreContextDidSaveRemoteValues`.

The probleme here was that CoreData removes the objects from the sets
referenced in the original request as they are saved. This means that
from a notification handler for
`AFIncrementalStoreContextDidSaveRemoteValues` you are provided with an
`NSSaveChangesRequest`instance whose sets are either empty or nil,
leaving you unable to get a reference on the managed objects.

This is fixed here by creating a new NSSaveChangesRequest with copies of
the original sets.

This works fine for my purpose, so far but could there be some unexpected side-effects?
