### PR TITLE
Removing confusing log 

### DIFF
--- a/Examples/Basic Example/AppDelegate.m
+++ b/Examples/Basic Example/AppDelegate.m
@@ -112,8 +112,6 @@
         abort();
     }
     
-    NSLog(@"SQLite URL: %@", [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"Songs.sqlite"]);
-    
     return __persistentStoreCoordinator;
 }
 


### PR DESCRIPTION
The example is logging the SQLite file/location. Since the example uses an `NSInMemoryStoreType` (as fallback?), there is no SQLite involved.  
