### PR TITLE
relationshipValue in backingObject get lost while updateBackingObject

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -220,7 +220,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                 mutableBackingRelationshipValue = [NSMutableSet setWithCapacity:[relationshipValue count]];
             }
             
-            for (NSManagedObject *relationshipManagedObject in mutableBackingRelationshipValue) {
+            for (NSManagedObject *relationshipManagedObject in relationshipValue) {
 				if (![[relationshipManagedObject objectID] isTemporaryID]) {
 					NSManagedObjectID *backingRelationshipObjectID = [self objectIDForBackingObjectForEntity:relationship.destinationEntity withResourceIdentifier:AFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:relationshipManagedObject.objectID])];
 					if (backingRelationshipObjectID) {


### PR DESCRIPTION
The method `updateBackingObject` transfer the relationship value of managedObject into backingObject. There is a typo that a nil value `mutableBackingRelationshipValue` is transferred. So the existing relationship value of backingObject get lost after this method.
