### PR TITLE
typo in attributesForRepresentation

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -207,7 +207,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
     NSMutableDictionary *mutableAttributes = [representation mutableCopy];
     @autoreleasepool {
         NSMutableSet *mutableKeys = [NSMutableSet setWithArray:[representation allKeys]];
-        [mutableKeys minusSet:[NSSet setWithArray:[[entity propertiesByName] allKeys]]];
+        [mutableKeys minusSet:[NSSet setWithArray:[[entity attributesByName] allKeys]]];
         [mutableAttributes removeObjectsForKeys:[mutableKeys allObjects]];
     }
     


### PR DESCRIPTION
The purpose of attributesForRepresentation is to delete keys and values of representation except attributes of entity. So the `mutableKeys` should minusSet `[entity attributesByName]` instead of `[entity propertiesByName]`. The propertiesByName includes relationship of entity.
