### PR TITLE
Filter out transient attributes from fetchRequest propertiesToFetch: 

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -667,7 +667,16 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
     fetchRequest.resultType = NSDictionaryResultType;
     fetchRequest.fetchLimit = 1;
     fetchRequest.includesSubentities = NO;
-    fetchRequest.propertiesToFetch = [[[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allKeys] arrayByAddingObject:kAFIncrementalStoreLastModifiedAttributeName];
+    NSArray *attributes = [[[NSEntityDescription entityForName:fetchRequest.entityName inManagedObjectContext:context] attributesByName] allValues];
+    NSMutableArray *validProperties = [[NSMutableArray alloc] initWithCapacity:attributes.count];
+    for (NSAttributeDescription *attribute in attributes){
+        if ([attribute isTransient] == FALSE) {
+            [validProperties addObject:attribute];
+        }
+    }
+    
+    NSArray *propertyNames = [validProperties valueForKey:@"name"];
+    fetchRequest.propertiesToFetch = [propertyNames arrayByAddingObject:kAFIncrementalStoreLastModifiedAttributeName];
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"%K = %@", kAFIncrementalStoreResourceIdentifierAttributeName, AFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:objectID])];
     
     __block NSArray *results;


### PR DESCRIPTION
Need to filter out transient attributes from fetchRequest.propertiesToFetch or it will throw an exception "defaultValue (null)) passed to setPropertiesToFetch: (entity mismatch)". This is because transient attributes aren't actually created at the data level, they're calculated at run-time. The Core Data programming guide alludes to this: "You cannot fetch using a predicate based on transient properties"
