### PR TITLE
Put _id in candidateKeys

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -182,7 +182,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
     static NSArray *_candidateKeys = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _candidateKeys = [[NSArray alloc] initWithObjects:@"id", @"identifier", @"url", @"URL", nil];
+        _candidateKeys = [[NSArray alloc] initWithObjects:@"id", @"_id", @"identifier", @"url", @"URL", nil];
     });
     
     NSString *key = [[representation allKeys] firstObjectCommonWithArray:_candidateKeys];


### PR DESCRIPTION
There are some databases (MongoDB) that use _id as a default identifier. When you have just simple REST server that display db request and you are using sample code from examples your app will crash without much information. 

Putting _id into candidateKeys will solve this beginner problem and I also think it fits those keys nicely. 
