### PR TITLE
Add support for foreign relationship identifier

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -167,6 +167,13 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
                                 
                 [mutableRelationshipRepresentations setValue:arrayOfRelationshipRepresentations forKey:name];
             } else {
+                if ([value isKindOfClass:[NSString class]]) {
+                    // support relation by hyperlinked identifier
+                    value = @{@"url": value};
+                } else if ([value isKindOfClass:[NSNumber class]]) {
+                    // support relation by id
+                    value = @{@"id": value};
+                }
                 [mutableRelationshipRepresentations setValue:value forKey:name];
             }
         }


### PR DESCRIPTION
A lot of APIs are now referencing relationships with an hyperlinked identifier or an id. 

Mine for example looks like this :  

``` ruby
{
    "url": "/coupons/39",     # object identifier
    "user": "/users/1",       # relationship identifier
    "date_created": "2013-03-16T11:36:11.687345+00:00", 
    ...
}
```

I think if the identifier is an ID, the developer will also need to implement `requestWithMethod:pathForRelationship:forObjectWithID:withContext:` to use the correct api request path. I don't think we should take a decision for him here, that's why I didn't support that.

This is clearly linked to the PR #62, nevertheless I thought it'd be clearer with only those few lines.
