### PR TITLE
Fix an issue, when the CoreData model is an NSDate, but the web service ...

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -236,7 +236,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
     [[entity attributesByName] enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         if ([(NSAttributeDescription *)obj attributeType] == NSDateAttributeType) {
             id value = [mutableAttributes valueForKey:key];
-            if (value && ![value isEqual:[NSNull null]]) {
+            if (value && ![value isEqual:[NSNull null]] && [value isKindOfClass:NSString.class]) {
                 [mutableAttributes setValue:AFDateFromISO8601String(value) forKey:key];
             }
         }


### PR DESCRIPTION
...is returning an NSNumber, not a string for the date.

This fix will make sure that we call AFDateFromISO8601String only on values of class NSString.
