### PR TITLE
app crashes when fetching attribute values by count or sum functions

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -439,6 +439,32 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
             return managedObjectIDs;
         }
         case NSDictionaryResultType:
+            if (fetchRequest.propertiesToFetch) {
+                NSMutableArray *fetchProperties = [NSMutableArray array];
+                for (id object in fetchRequest.propertiesToFetch) {
+                    if ([object isKindOfClass:[NSExpressionDescription class]]) {
+                        [fetchProperties addObject:object];
+                    } else {
+                        NSPropertyDescription *property = (NSPropertyDescription *)object;
+                        NSEntityDescription *entity = [NSEntityDescription entityForName:property.entity.name inManagedObjectContext:backingContext];
+                        [fetchProperties addObject:[entity.propertiesByName objectForKey:property.name]];
+                    }
+                }
+                [backingFetchRequest setPropertiesToFetch:fetchProperties];
+            }
+            if (fetchRequest.propertiesToGroupBy) {
+                NSMutableArray *groupByProperties = [NSMutableArray array];
+                for (id object in fetchRequest.propertiesToGroupBy) {
+                    if ([object isKindOfClass:[NSExpressionDescription class]]) {
+                        [groupByProperties addObject:object];
+                    } else {
+                        NSPropertyDescription *property = (NSPropertyDescription *)object;
+                        NSEntityDescription *entity = [NSEntityDescription entityForName:property.entity.name inManagedObjectContext:backingContext];
+                        [groupByProperties addObject:[entity.attributesByName objectForKey:property.name]];
+                    }
+                }
+                [backingFetchRequest setPropertiesToGroupBy:groupByProperties];
+            }
         case NSCountResultType:
             return [backingContext executeFetchRequest:backingFetchRequest error:error];
         default:


### PR DESCRIPTION
when fetching attribute values that satisfy a given function such as count, sum etc, the app will crashes with message:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Invalid property ((<NSAttributeDescription: 0x1f8a2750>), name countMember, isOptional 1, isTransient 0, entity Transaction, renamingIdentifier action, validation predicates (
), warnings (
), versionHashModifier (null)
 userInfo {
}, attributeType 100 , attributeValueClassName NSNumber, defaultValue 0) passed to setPropertiesToFetch: (entity mismatch)'.
```

The fetching snippet I used looks like below:

```
NSExpressionDescription *amountDescription = [[NSExpressionDescription alloc] init];
[amountDescription setName:@"amount"];
[amountDescription setExpression:[NSExpression expressionForKeyPath:@"@sum.amount"]];
[amountDescription setExpressionResultType:NSInteger32AttributeType];

NSFetchRequest *fetchTransaction = [NSFetchRequest fetchRequestWithEntityName:@"Transaction"];
[fetchTransaction setPredicate:[NSPredicate predicateWithFormat:@"shopId = %@", shop[@"shopId"]]];
[fetchTransaction setPropertiesToFetch:@[@"action", amountDescription]];
[fetchTransaction setPropertiesToGroupBy:@[@"action"]];
[fetchTransaction setResultType:NSDictionaryResultType];

[_managedObjectContext performBlockAndWait:^{
    NSError *error = nil;
    NSArray *transactionResults = [_managedObjectContext executeFetchRequest:fetchTransaction error:&error];
    if ([transactionResults lastObject]) {
        NSLog(@"%@", transactionResults);
    }
}];
```

This fixes the bug by transfer the propertiesToFetch and propertiesToGroupBy from fetchRequest to backingFetchRequest. fetchRequest and backingFetchRequest are in different NSManagedObjectContext.
