### PR TITLE
Use backing objects ID's when looking for backing object.

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -477,15 +477,15 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
             
             AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
                 NSString *resourceIdentifier = [self.HTTPClient resourceIdentifierForRepresentation:responseObject ofEntity:[insertedObject entity] fromResponse:operation.response];
-                NSManagedObjectID *objectID = [self objectIDForEntity:[insertedObject entity] withResourceIdentifier:resourceIdentifier];
+                NSManagedObjectID *backingObjectID = [self objectIDForBackingObjectForEntity:[insertedObject entity] withResourceIdentifier:resourceIdentifier];
                 insertedObject.af_resourceIdentifier = resourceIdentifier;
                 [insertedObject setValuesForKeysWithDictionary:[self.HTTPClient attributesForRepresentation:responseObject ofEntity:insertedObject.entity fromResponse:operation.response]];
                 
                 [backingContext performBlockAndWait:^{
                     __block NSManagedObject *backingObject = nil;
-                    if (objectID) {
+                    if (backingObjectID) {
                         [backingContext performBlockAndWait:^{
-                            backingObject = [backingContext existingObjectWithID:objectID error:nil];
+                            backingObject = [backingContext existingObjectWithID:backingObjectID error:nil];
                         }];
                     }
                     


### PR DESCRIPTION
When inserting objects, if we are going to search the backing context for existing objects, we need to use the objectID from the backing context.

This was especially troublesome in cases where an object has no identifier until the server responds. In some cases, if the server responds with an identifier that is already known locally, objects with duplicate ID's would be created.
