### PR TITLE
Fixed problem with saving contexts that lead to segmentations faults.

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -737,11 +737,17 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
                     [strongChildContext performBlockAndWait:^{
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            NSError *__autoreleasing *errorToThrow = nil;
                             if (error == NULL)
                             {
-                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                NSError __autoreleasing *unknownError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                errorToThrow = &unknownError;
                             }
-                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
+                            else
+                            {
+                                errorToThrow = error;
+                            }
+                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*errorToThrow localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*errorToThrow forKey:NSUnderlyingErrorKey]];
                         }
                     }];
                     
@@ -800,11 +806,17 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                         }];
                         
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            NSError *__autoreleasing *errorToThrow = nil;
                             if (error == NULL)
                             {
-                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                NSError __autoreleasing *unknownError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                errorToThrow = &unknownError;
                             }
-                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
+                            else
+                            {
+                                errorToThrow = error;
+                            }
+                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*errorToThrow localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*errorToThrow forKey:NSUnderlyingErrorKey]];
                         }
                         
                         [[NSNotificationCenter defaultCenter] removeObserver:observer];

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -23,6 +23,7 @@
 #import "AFIncrementalStore.h"
 #import "AFHTTPClient.h"
 #import <objc/runtime.h>
+#import <CoreData/CoreDataErrors.h>
 
 NSString * const AFIncrementalStoreUnimplementedMethodException = @"com.alamofire.incremental-store.exceptions.unimplemented-method";
 
@@ -736,6 +737,10 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
                     [strongChildContext performBlockAndWait:^{
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            if (error == NULL)
+                            {
+                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                            }
                             @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
                         }
                     }];
@@ -795,6 +800,10 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                         }];
                         
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            if (error == NULL)
+                            {
+                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                            }
                             @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
                         }
                         


### PR DESCRIPTION
When saving the contexts in `newValuesForObjectWithID:...` and `newValuesForRelationship:...`, it might happen under yet unclear conditions that the save operations don't finish successfully but don't leave any error behind. In consequence it will be attempted to dereference a NULL pointer to an error object within the subsequent `@throw` statement, leading to an EXC_BAD_ACCESS, code 2. I already described this bug [here](https://github.com/AFNetworking/AFIncrementalStore/issues/183), but couldn't come up with a solution until now.

This unwanted crash can be circumvented by generating a general CoreData error and assigning it to `error`, if `error` is NULL at a failed save request.
