### PR TITLE
Fixes an always nil context when fetching remote attributes.

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -712,8 +712,8 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                 }
 
                 __weak NSManagedObjectContext *weakChildContext = childContext;
+				__strong NSManagedObjectContext *strongChildContext = weakChildContext;
                 AFHTTPRequestOperation *operation = [self.HTTPClient HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, NSDictionary *representation) {
-                    __strong NSManagedObjectContext *strongChildContext = weakChildContext;
                     NSManagedObject *managedObject = [strongChildContext existingObjectWithID:objectID error:error];
                     
                     NSMutableDictionary *mutableAttributeValues = [attributeValues mutableCopy];


### PR DESCRIPTION
Commit 1f82227 added weak and strong pointers to the child managed object context. Unfortunately, the strong context referenced in the success block of the HTTP request (sent for fetching remote attributes) is always nil. Because of this, the request fails to add the fetched values to an object. I commented on the commit, here. (https://github.com/AFNetworking/AFIncrementalStore/commit/1f822279e6a7096327ae56a2f65ce8e2ff36da83)

Pull request #191 seems to be related. I'm not sure if the effort to resolve the deadlock in 1f82227 was successful because of the weak/strong relationships, or because the HTTP response block was always talking to a nil context -- @mattt will have to shed some light on his thinking there.
