### PR TITLE
Small fixes

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -737,11 +737,17 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
                     [strongChildContext performBlockAndWait:^{
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            NSError *__autoreleasing *errorToThrow = nil;
                             if (error == NULL)
                             {
-                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                NSError __autoreleasing *unknownError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                errorToThrow = &unknownError;
                             }
-                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
+                            else
+                            {
+                                errorToThrow = error;
+                            }
+                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*errorToThrow localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*errorToThrow forKey:NSUnderlyingErrorKey]];
                         }
                     }];
                     
@@ -800,11 +806,17 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                         }];
                         
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            NSError *__autoreleasing *errorToThrow = nil;
                             if (error == NULL)
                             {
-                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                NSError __autoreleasing *unknownError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                                errorToThrow = &unknownError;
                             }
-                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
+                            else
+                            {
+                                errorToThrow = error;
+                            }
+                            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*errorToThrow localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*errorToThrow forKey:NSUnderlyingErrorKey]];
                         }
                         
                         [[NSNotificationCenter defaultCenter] removeObserver:observer];

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -373,11 +373,6 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                     if (![[self backingManagedObjectContext] save:error] || ![childContext save:error]) {
                         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
                     }
-                    
-                    for (NSManagedObject *childObject in childObjects) {
-                        NSManagedObject *parentObject = [context objectWithID:childObject.objectID];
-                        [parentObject.managedObjectContext refreshObject:parentObject mergeChanges:NO];
-                    }
 
                     [context performBlockAndWait:^{
                         for (NSManagedObject *childObject in childObjects) {

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -23,6 +23,7 @@
 #import "AFIncrementalStore.h"
 #import "AFHTTPClient.h"
 #import <objc/runtime.h>
+#import <CoreData/CoreDataErrors.h>
 
 NSString * const AFIncrementalStoreUnimplementedMethodException = @"com.alamofire.incremental-store.exceptions.unimplemented-method";
 
@@ -736,6 +737,10 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 
                     [strongChildContext performBlockAndWait:^{
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            if (error == NULL)
+                            {
+                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                            }
                             @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
                         }
                     }];
@@ -795,6 +800,10 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                         }];
                         
                         if (![[self backingManagedObjectContext] save:error] || ![strongChildContext save:error]) {
+                            if (error == NULL)
+                            {
+                                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSCoreDataError userInfo:[NSDictionary dictionary]];
+                            }
                             @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[*error localizedFailureReason] userInfo:[NSDictionary dictionaryWithObject:*error forKey:NSUnderlyingErrorKey]];
                         }
                         


### PR DESCRIPTION
While searching for potential deadlocks, I discovered a few lines of deprecated code within `executeFetchRequest:...` apparently left over from a previous fix. I removed them for good, since their functionality is replaced immediately after them with a better, more stable version.
