### PR TITLE
Remove the AFDateFromISO8601String function reference

### DIFF
--- a/AFIncrementalStore/AFRESTClient.h
+++ b/AFIncrementalStore/AFRESTClient.h
@@ -83,15 +83,6 @@
 
 @end
 
-///----------------
-/// @name Functions
-///----------------
-
-/**
- 
- */
-extern NSDate * AFDateFromISO8601String(NSString *ISO8601String);
-
 ///-----------------
 /// @name Pagination
 ///-----------------


### PR DESCRIPTION
Very small contribution but it cleans up the header file and avoid errors when updating from a _very old_ version of `AFIncrementalStore` :)
