### PR TITLE
Fix wrong (reversed) usage of TTTISO8601DateTransformer

### DIFF
--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -180,7 +180,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
         if ([(NSAttributeDescription *)obj attributeType] == NSDateAttributeType) {
             id value = [mutableAttributes valueForKey:key];
             if (value && ![value isEqual:[NSNull null]] && [value isKindOfClass:[NSString class]]) {
-                [mutableAttributes setValue:[[NSValueTransformer valueTransformerForName:TTTISO8601DateTransformerName] transformedValue:value] forKey:key];
+                [mutableAttributes setValue:[[NSValueTransformer valueTransformerForName:TTTISO8601DateTransformerName] reverseTransformedValue:value] forKey:key];
             }
         }
     }];

--- a/Examples/Twitter Client/Classes/AppDotNetAPIClient.m
+++ b/Examples/Twitter Client/Classes/AppDotNetAPIClient.m
@@ -90,7 +90,7 @@ static NSString * const kAFAppDotNetAPIBaseURLString = @"https://alpha-api.app.n
     NSMutableDictionary *mutablePropertyValues = [[super attributesForRepresentation:representation ofEntity:entity fromResponse:response] mutableCopy];
     if ([entity.name isEqualToString:@"Post"]) {
         [mutablePropertyValues setValue:[NSNumber numberWithInteger:[[representation valueForKey:@"id"] integerValue]] forKey:@"postID"];
-        [mutablePropertyValues setValue:[[NSValueTransformer valueTransformerForName:TTTISO8601DateTransformerName] transformedValue:[representation valueForKey:@"created_at"]] forKey:@"createdAt"];
+        [mutablePropertyValues setValue:[[NSValueTransformer valueTransformerForName:TTTISO8601DateTransformerName] reverseTransformedValue:[representation valueForKey:@"created_at"]] forKey:@"createdAt"];
     } else if ([entity.name isEqualToString:@"User"]) {
         [mutablePropertyValues setValue:[NSNumber numberWithInteger:[[representation valueForKey:@"id"] integerValue]] forKey:@"userID"];
         [mutablePropertyValues setValue:[representation valueForKey:@"username"] forKey:@"username"];


### PR DESCRIPTION
Fixes #192: The TTTISO8601DateTransformer has been used in the wrong direction:
instead of converting from a string to a date, it tried to convert from
a date to a string which fails silently everytime.
