### PR TITLE
Prevent dangling relationships when an insert save fails

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -563,7 +563,9 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
 						destinationObjects = [insertedObject valueForKey:relationshipName];
 					} else {
 						NSManagedObject *destinationObject = [insertedObject valueForKey:relationshipName];
-						destinationObjects = @[destinationObject];
+						if (destinationObject) {
+							destinationObjects = @[destinationObject];
+						}
 					}
 					
 					for (NSManagedObject *destinationObject in destinationObjects) {


### PR DESCRIPTION
I spent a _hell_ of a lot of hours trying to figure this one out -- and it's possible someone smarter at Core Data has a better solution. The issue was caused by doing the following:
### Model
- ModelA has one to one relationship with ModelB
### Data Flow
- Fetch instance of ModelA -- it's saved to the backing store with a permanent ID
- Create local instance of ModelB, associate it with the previously fetched instance of ModelB
- Save ModelB.
- When the server communication fails, ModelB does not receive a permanent ID.

At this point, the instance of ModelB still exists, but (at least according to my debugging) no longer exists in the managedObjectContext. All subsequent saves fail with a Core Data error: `dangling reference to an invalid object`.

Trying to manually nil the relationships on ModelB upsets Core Data, and it tells me: `Cannot update object that was never inserted`. Manually setting the inverse relationships causes a similar error.

I was finally able to fix by the problem by refreshing all the objects at the other side of any of the relationships of ModelB.
