### PR TITLE
Specified AFNetworking to match version 1.3.2

### DIFF
--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency 'AFNetworking', '>= 1.0'
+  s.dependency 'AFNetworking', '~> 1.3.2'
   s.dependency 'InflectorKit'
   s.dependency 'TransformerKit'
 end


### PR DESCRIPTION
Due to AFNetworking being on 2.0.0 RC1 AFIncremental store was picking
it up as it's dependency and thus reporting compiler errors in
AFNetworking.
