### PR TITLE
Update AFIncrementalStore to AFNetworking 2.0.0

### DIFF
--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.author       = { "Mattt Thompson" => "m@mattt.me" }
   s.license      = 'MIT'
 
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.7'
 
   s.source       = { :git => "https://github.com/Nitewriter/AFIncrementalStore.git", :tag => "0.6.0" }

--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency 'AFNetworking', '~> 2.0.0-RC2'
+  s.dependency 'AFNetworking', '~> 2.0.0'
   s.dependency 'InflectorKit'
   s.dependency 'TransformerKit'
 end

--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AFIncrementalStore"
-  s.version      = "0.5.1"
+  s.version      = "0.6.0"
   s.summary      = "Core Data Persistence with AFNetworking, Done Right."
   s.homepage     = "https://github.com/AFNetworking/AFIncrementalStore"
   s.author       = { "Mattt Thompson" => "m@mattt.me" }
@@ -9,14 +9,14 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
 
-  s.source       = { :git => "https://github.com/AFNetworking/AFIncrementalStore.git", :tag => "0.5.1" }
+  s.source       = { :git => "https://github.com/Nitewriter/AFIncrementalStore.git", :tag => "0.6.0" }
   s.source_files = 'AFIncrementalStore/*.{h,m}'
 
   s.framework  = 'CoreData'
 
   s.requires_arc = true
 
-  s.dependency 'AFNetworking', '~> 1.3.2'
+  s.dependency 'AFNetworking', '~> 2.0.0-RC2'
   s.dependency 'InflectorKit'
   s.dependency 'TransformerKit'
 end

--- a/AFIncrementalStore/AFIncrementalStore.h
+++ b/AFIncrementalStore/AFIncrementalStore.h
@@ -57,7 +57,7 @@
 /**
  The HTTP client used to manage requests and responses with the associated web services.
  */
-@property (nonatomic, strong) AFHTTPClient <AFIncrementalStoreHTTPClient> *HTTPClient;
+@property (nonatomic, strong) AFHTTPRequestOperationManager <AFIncrementalStoreHTTPClient> *HTTPClient;
 
 /**
  The persistent store coordinator used to persist data from the associated web serivices locally.

--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -800,6 +800,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                             NSManagedObjectContext *backingContext = [self backingManagedObjectContext];
                             [backingContext performBlockAndWait:^{
                                 AFSaveManagedObjectContextOrThrowInternalConsistencyException(backingContext);
+                                [operation isFinished];
                             }];
                         }];
                         

--- a/AFIncrementalStore/AFRESTClient.h
+++ b/AFIncrementalStore/AFRESTClient.h
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPClient.h"
-#import "AFHTTPRequestOperation.h"
+
+#import <AFNetworking/AFNetworking.h>
 #import "AFIncrementalStore.h"
 #import "TTTStringInflector.h"
 
@@ -30,7 +30,7 @@
 /**
  `AFRESTClient` is a subclass of `AFHTTPClient` that implements the `AFIncrementalStoreHTTPClient` protocol in a way that follows the conventions of a RESTful web service.
  */
-@interface AFRESTClient : AFHTTPClient <AFIncrementalStoreHTTPClient>
+@interface AFRESTClient : AFHTTPRequestOperationManager <AFIncrementalStoreHTTPClient>
 
 /**
  

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -24,6 +24,7 @@
 
 #import "TTTDateTransformers.h"
 
+#if 0
 static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *parameters) {
     static NSCharacterSet *_componentSeparatorCharacterSet = nil;
     static dispatch_once_t onceToken;
@@ -44,6 +45,9 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
 
     return [query stringByAppendingString:[mutablePairs componentsJoinedByString:@"&"]];
 }
+#endif
+
+#define URLStringWithBase(u) [[NSURL URLWithString:(u) relativeToURL:self.baseURL] absoluteString]
 
 @interface AFRESTClient ()
 @property (readwrite, nonatomic, strong) TTTStringInflector *inflector;
@@ -195,9 +199,10 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
     if (self.paginator) {
         [mutableParameters addEntriesFromDictionary:[self.paginator parametersForFetchRequest:fetchRequest]];
     }
-    
-    NSMutableURLRequest *mutableRequest = [self requestWithMethod:@"GET"
-                                                        URLString:[self pathForEntity:fetchRequest.entity]
+
+    NSMutableURLRequest *mutableRequest = [self.requestSerializer
+                                                requestWithMethod:@"GET"
+                                                        URLString:URLStringWithBase([self pathForEntity:fetchRequest.entity])
                                                        parameters:[mutableParameters count] == 0 ? nil : mutableParameters];
     
     return mutableRequest;
@@ -208,7 +213,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
                                withContext:(NSManagedObjectContext *)context
 {
     NSManagedObject *object = [context objectWithID:objectID];
-    return [self requestWithMethod:method URLString:[self pathForObject:object] parameters:nil];
+    return [self.requestSerializer requestWithMethod:method URLString:URLStringWithBase([self pathForObject:object]) parameters:nil];
 }
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
@@ -217,7 +222,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
                                withContext:(NSManagedObjectContext *)context
 {
     NSManagedObject *object = [context objectWithID:objectID];
-    return [self requestWithMethod:method URLString:[self pathForRelationship:relationship forObject:object] parameters:nil];
+    return [self.requestSerializer requestWithMethod:method URLString:URLStringWithBase([self pathForRelationship:relationship forObject:object]) parameters:nil];
 }
 
 - (BOOL)shouldFetchRemoteValuesForRelationship:(NSRelationshipDescription *)relationship
@@ -244,7 +249,10 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
 }
 
 - (NSMutableURLRequest *)requestForInsertedObject:(NSManagedObject *)insertedObject {
-    return [self requestWithMethod:@"POST" URLString:[self pathForEntity:insertedObject.entity] parameters:[self representationOfAttributes:[insertedObject dictionaryWithValuesForKeys:[insertedObject.entity.attributesByName allKeys]] ofManagedObject:insertedObject]];
+    return [self.requestSerializer
+            requestWithMethod:@"POST"
+            URLString:URLStringWithBase([self pathForEntity:insertedObject.entity])
+            parameters:[self representationOfAttributes:[insertedObject dictionaryWithValuesForKeys:[insertedObject.entity.attributesByName allKeys]] ofManagedObject:insertedObject]];
 }
 
 - (NSMutableURLRequest *)requestForUpdatedObject:(NSManagedObject *)updatedObject {
@@ -254,11 +262,17 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
         return nil;
     }
     
-    return [self requestWithMethod:@"PUT" URLString:[self pathForObject:updatedObject] parameters:[self representationOfAttributes:[[updatedObject changedValues] dictionaryWithValuesForKeys:[mutableChangedAttributeKeys allObjects]] ofManagedObject:updatedObject]];
+    return [self.requestSerializer
+            requestWithMethod:@"PUT"
+            URLString:URLStringWithBase([self pathForObject:updatedObject])
+            parameters:[self representationOfAttributes:[[updatedObject changedValues] dictionaryWithValuesForKeys:[mutableChangedAttributeKeys allObjects]] ofManagedObject:updatedObject]];
 }
 
 - (NSMutableURLRequest *)requestForDeletedObject:(NSManagedObject *)deletedObject {
-    return [self requestWithMethod:@"DELETE" URLString:[self pathForObject:deletedObject] parameters:nil];
+    return [self.requestSerializer
+            requestWithMethod:@"DELETE"
+            URLString:URLStringWithBase([self pathForObject:deletedObject])
+            parameters:nil];
 }
 
 @end

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -196,7 +196,9 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
         [mutableParameters addEntriesFromDictionary:[self.paginator parametersForFetchRequest:fetchRequest]];
     }
     
-    NSMutableURLRequest *mutableRequest =  [self requestWithMethod:@"GET" path:[self pathForEntity:fetchRequest.entity] parameters:[mutableParameters count] == 0 ? nil : mutableParameters];
+    NSMutableURLRequest *mutableRequest = [self requestWithMethod:@"GET"
+                                                        URLString:[self pathForEntity:fetchRequest.entity]
+                                                       parameters:[mutableParameters count] == 0 ? nil : mutableParameters];
     
     return mutableRequest;
 }
@@ -206,7 +208,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
                                withContext:(NSManagedObjectContext *)context
 {
     NSManagedObject *object = [context objectWithID:objectID];
-    return [self requestWithMethod:method path:[self pathForObject:object] parameters:nil];
+    return [self requestWithMethod:method URLString:[self pathForObject:object] parameters:nil];
 }
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
@@ -215,7 +217,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
                                withContext:(NSManagedObjectContext *)context
 {
     NSManagedObject *object = [context objectWithID:objectID];
-    return [self requestWithMethod:method path:[self pathForRelationship:relationship forObject:object] parameters:nil];
+    return [self requestWithMethod:method URLString:[self pathForRelationship:relationship forObject:object] parameters:nil];
 }
 
 - (BOOL)shouldFetchRemoteValuesForRelationship:(NSRelationshipDescription *)relationship
@@ -242,7 +244,7 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
 }
 
 - (NSMutableURLRequest *)requestForInsertedObject:(NSManagedObject *)insertedObject {
-    return [self requestWithMethod:@"POST" path:[self pathForEntity:insertedObject.entity] parameters:[self representationOfAttributes:[insertedObject dictionaryWithValuesForKeys:[insertedObject.entity.attributesByName allKeys]] ofManagedObject:insertedObject]];
+    return [self requestWithMethod:@"POST" URLString:[self pathForEntity:insertedObject.entity] parameters:[self representationOfAttributes:[insertedObject dictionaryWithValuesForKeys:[insertedObject.entity.attributesByName allKeys]] ofManagedObject:insertedObject]];
 }
 
 - (NSMutableURLRequest *)requestForUpdatedObject:(NSManagedObject *)updatedObject {
@@ -252,11 +254,11 @@ static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *pa
         return nil;
     }
     
-    return [self requestWithMethod:@"PUT" path:[self pathForObject:updatedObject] parameters:[self representationOfAttributes:[[updatedObject changedValues] dictionaryWithValuesForKeys:[mutableChangedAttributeKeys allObjects]] ofManagedObject:updatedObject]];
+    return [self requestWithMethod:@"PUT" URLString:[self pathForObject:updatedObject] parameters:[self representationOfAttributes:[[updatedObject changedValues] dictionaryWithValuesForKeys:[mutableChangedAttributeKeys allObjects]] ofManagedObject:updatedObject]];
 }
 
 - (NSMutableURLRequest *)requestForDeletedObject:(NSManagedObject *)deletedObject {
-    return [self requestWithMethod:@"DELETE" path:[self pathForObject:deletedObject] parameters:nil];
+    return [self requestWithMethod:@"DELETE" URLString:[self pathForObject:deletedObject] parameters:nil];
 }
 
 @end

--- a/Examples/Basic Example/AppDelegate.m
+++ b/Examples/Basic Example/AppDelegate.m
@@ -23,6 +23,8 @@
 #import "AppDelegate.h"
 #import "SongsIncrementalStore.h"
 #import "ArtistsListViewController.h"
+#import "AFNetworkActivityIndicatorManager.h"
+
 
 @implementation AppDelegate
 @synthesize window = _window;

--- a/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
+++ b/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
@@ -7,17 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BD19794F17CF965C00958CDC /* AFEventSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794617CF965C00958CDC /* AFEventSource.m */; };
-		BD19795017CF965C00958CDC /* AFHTTPClient+Rocket.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */; };
-		BD19795117CF965C00958CDC /* AFJSONPatchSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */; };
-		BD19795217CF965C00958CDC /* AFSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794C17CF965C00958CDC /* AFSerialization.m */; };
-		BD19795317CF965C00958CDC /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794E17CF965C00958CDC /* AFURLSessionManager.m */; };
-		BD19796017CF968400958CDC /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */; };
-		BD19796117CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */; };
-		BD19796217CF968400958CDC /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795917CF968400958CDC /* UIButton+AFNetworking.m */; };
-		BD19796317CF968400958CDC /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */; };
-		BD19796417CF968400958CDC /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */; };
-		BD19796517CF968400958CDC /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */; };
+		74FD2FE117F9799100DF04E8 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74FD2FE017F9799100DF04E8 /* Security.framework */; };
+		74FD2FF617F986B900DF04E8 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FE417F986B900DF04E8 /* AFHTTPRequestOperation.m */; };
+		74FD2FF717F986B900DF04E8 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FE617F986B900DF04E8 /* AFHTTPRequestOperationManager.m */; };
+		74FD2FF817F986B900DF04E8 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FE817F986B900DF04E8 /* AFHTTPSessionManager.m */; };
+		74FD2FF917F986B900DF04E8 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FEB17F986B900DF04E8 /* AFNetworkReachabilityManager.m */; };
+		74FD2FFA17F986B900DF04E8 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FED17F986B900DF04E8 /* AFSecurityPolicy.m */; };
+		74FD2FFB17F986B900DF04E8 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FEF17F986B900DF04E8 /* AFURLConnectionOperation.m */; };
+		74FD2FFC17F986B900DF04E8 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FF117F986B900DF04E8 /* AFURLRequestSerialization.m */; };
+		74FD2FFD17F986B900DF04E8 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FF317F986B900DF04E8 /* AFURLResponseSerialization.m */; };
+		74FD2FFE17F986B900DF04E8 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD2FF517F986B900DF04E8 /* AFURLSessionManager.m */; };
+		74FD300417F986CA00DF04E8 /* AFIncrementalStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD300117F986CA00DF04E8 /* AFIncrementalStore.m */; };
+		74FD300517F986CA00DF04E8 /* AFRESTClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD300317F986CA00DF04E8 /* AFRESTClient.m */; };
+		74FD300817F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FD300717F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.m */; };
 		F81D904116F3DED80043C85A /* NSValueTransformer+TransformerKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D903B16F3DED80043C85A /* NSValueTransformer+TransformerKit.m */; };
 		F81D904916F3DEEB0043C85A /* NSString+InflectorKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904616F3DEEB0043C85A /* NSString+InflectorKit.m */; };
 		F81D904A16F3DEEB0043C85A /* TTTStringInflector.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904816F3DEEB0043C85A /* TTTStringInflector.m */; };
@@ -33,15 +35,6 @@
 		F8874F1F15B08C2A0048680F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F8874F1E15B08C2A0048680F /* main.m */; };
 		F8874F2015B08C4B0048680F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F8874F1B15B08BD30048680F /* AppDelegate.m */; };
 		F8874F2315B08CA80048680F /* IncrementalStoreExample.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F8874F2115B08CA80048680F /* IncrementalStoreExample.xcdatamodeld */; };
-		F8AD92D815D9A0B400402FE9 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C415D9A0B400402FE9 /* AFHTTPClient.m */; };
-		F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C615D9A0B400402FE9 /* AFHTTPRequestOperation.m */; };
-		F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */; };
-		F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */; };
-		F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */; };
-		F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */; };
-		F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */; };
-		F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */; };
-		F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E615D9A0BB00402FE9 /* AFRESTClient.m */; };
 		F8AFAFB215AB4F28003FE5BB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AFAFB115AB4F28003FE5BB /* UIKit.framework */; };
 		F8AFAFB415AB4F28003FE5BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AFAFB315AB4F28003FE5BB /* Foundation.framework */; };
 		F8AFAFB615AB4F28003FE5BB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AFAFB515AB4F28003FE5BB /* CoreGraphics.framework */; };
@@ -52,28 +45,32 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BD19794517CF965C00958CDC /* AFEventSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFEventSource.h; sourceTree = "<group>"; };
-		BD19794617CF965C00958CDC /* AFEventSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFEventSource.m; sourceTree = "<group>"; };
-		BD19794717CF965C00958CDC /* AFHTTPClient+Rocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AFHTTPClient+Rocket.h"; sourceTree = "<group>"; };
-		BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AFHTTPClient+Rocket.m"; sourceTree = "<group>"; };
-		BD19794917CF965C00958CDC /* AFJSONPatchSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONPatchSerializer.h; sourceTree = "<group>"; };
-		BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONPatchSerializer.m; sourceTree = "<group>"; };
-		BD19794B17CF965C00958CDC /* AFSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSerialization.h; sourceTree = "<group>"; };
-		BD19794C17CF965C00958CDC /* AFSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSerialization.m; sourceTree = "<group>"; };
-		BD19794D17CF965C00958CDC /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
-		BD19794E17CF965C00958CDC /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
-		BD19795417CF968400958CDC /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
-		BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		BD19795617CF968400958CDC /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
-		BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
-		BD19795817CF968400958CDC /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
-		BD19795917CF968400958CDC /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
-		BD19795A17CF968400958CDC /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		BD19795C17CF968400958CDC /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
-		BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		BD19795E17CF968400958CDC /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		74FD2FE017F9799100DF04E8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		74FD2FE317F986B900DF04E8 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		74FD2FE417F986B900DF04E8 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		74FD2FE517F986B900DF04E8 /* AFHTTPRequestOperationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperationManager.h; sourceTree = "<group>"; };
+		74FD2FE617F986B900DF04E8 /* AFHTTPRequestOperationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperationManager.m; sourceTree = "<group>"; };
+		74FD2FE717F986B900DF04E8 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPSessionManager.h; sourceTree = "<group>"; };
+		74FD2FE817F986B900DF04E8 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		74FD2FE917F986B900DF04E8 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
+		74FD2FEA17F986B900DF04E8 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		74FD2FEB17F986B900DF04E8 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
+		74FD2FEC17F986B900DF04E8 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSecurityPolicy.h; sourceTree = "<group>"; };
+		74FD2FED17F986B900DF04E8 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSecurityPolicy.m; sourceTree = "<group>"; };
+		74FD2FEE17F986B900DF04E8 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
+		74FD2FEF17F986B900DF04E8 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
+		74FD2FF017F986B900DF04E8 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		74FD2FF117F986B900DF04E8 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		74FD2FF217F986B900DF04E8 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		74FD2FF317F986B900DF04E8 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		74FD2FF417F986B900DF04E8 /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
+		74FD2FF517F986B900DF04E8 /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
+		74FD300017F986CA00DF04E8 /* AFIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFIncrementalStore.h; sourceTree = "<group>"; };
+		74FD300117F986CA00DF04E8 /* AFIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFIncrementalStore.m; sourceTree = "<group>"; };
+		74FD300217F986CA00DF04E8 /* AFRESTClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFRESTClient.h; sourceTree = "<group>"; };
+		74FD300317F986CA00DF04E8 /* AFRESTClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFRESTClient.m; sourceTree = "<group>"; };
+		74FD300617F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "../../AFNetworking/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		74FD300717F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "../../AFNetworking/UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
 		F81D903A16F3DED80043C85A /* NSValueTransformer+TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValueTransformer+TransformerKit.h"; sourceTree = "<group>"; };
 		F81D903B16F3DED80043C85A /* NSValueTransformer+TransformerKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValueTransformer+TransformerKit.m"; sourceTree = "<group>"; };
 		F81D904016F3DED80043C85A /* TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformerKit.h; sourceTree = "<group>"; };
@@ -102,25 +99,6 @@
 		F8874F1C15B08BD30048680F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = SOURCE_ROOT; };
 		F8874F1E15B08C2A0048680F /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = SOURCE_ROOT; };
 		F8874F2215B08CA80048680F /* IncrementalStoreExample.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = IncrementalStoreExample.xcdatamodel; sourceTree = "<group>"; };
-		F8AD92C315D9A0B400402FE9 /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
-		F8AD92C415D9A0B400402FE9 /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
-		F8AD92C515D9A0B400402FE9 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		F8AD92C615D9A0B400402FE9 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92C715D9A0B400402FE9 /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFImageRequestOperation.h; sourceTree = "<group>"; };
-		F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
-		F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
-		F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
-		F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92D215D9A0B400402FE9 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
-		F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92E315D9A0BB00402FE9 /* AFIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFIncrementalStore.h; sourceTree = "<group>"; };
-		F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFIncrementalStore.m; sourceTree = "<group>"; };
-		F8AD92E515D9A0BB00402FE9 /* AFRESTClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFRESTClient.h; sourceTree = "<group>"; };
-		F8AD92E615D9A0BB00402FE9 /* AFRESTClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFRESTClient.m; sourceTree = "<group>"; };
 		F8AFAFAD15AB4F28003FE5BB /* Songs.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Songs.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8AFAFB115AB4F28003FE5BB /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		F8AFAFB315AB4F28003FE5BB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -139,6 +117,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				74FD2FE117F9799100DF04E8 /* Security.framework in Frameworks */,
 				F81D905E16F3E6C10043C85A /* MobileCoreServices.framework in Frameworks */,
 				F81D905C16F3E6BC0043C85A /* SystemConfiguration.framework in Frameworks */,
 				F8AFAFB215AB4F28003FE5BB /* UIKit.framework in Frameworks */,
@@ -151,6 +130,45 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		74FD2FE217F986B900DF04E8 /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				74FD2FE317F986B900DF04E8 /* AFHTTPRequestOperation.h */,
+				74FD2FE417F986B900DF04E8 /* AFHTTPRequestOperation.m */,
+				74FD2FE517F986B900DF04E8 /* AFHTTPRequestOperationManager.h */,
+				74FD2FE617F986B900DF04E8 /* AFHTTPRequestOperationManager.m */,
+				74FD2FE717F986B900DF04E8 /* AFHTTPSessionManager.h */,
+				74FD2FE817F986B900DF04E8 /* AFHTTPSessionManager.m */,
+				74FD2FE917F986B900DF04E8 /* AFNetworking.h */,
+				74FD2FEA17F986B900DF04E8 /* AFNetworkReachabilityManager.h */,
+				74FD2FEB17F986B900DF04E8 /* AFNetworkReachabilityManager.m */,
+				74FD2FEC17F986B900DF04E8 /* AFSecurityPolicy.h */,
+				74FD2FED17F986B900DF04E8 /* AFSecurityPolicy.m */,
+				74FD2FEE17F986B900DF04E8 /* AFURLConnectionOperation.h */,
+				74FD2FEF17F986B900DF04E8 /* AFURLConnectionOperation.m */,
+				74FD2FF017F986B900DF04E8 /* AFURLRequestSerialization.h */,
+				74FD2FF117F986B900DF04E8 /* AFURLRequestSerialization.m */,
+				74FD2FF217F986B900DF04E8 /* AFURLResponseSerialization.h */,
+				74FD2FF317F986B900DF04E8 /* AFURLResponseSerialization.m */,
+				74FD2FF417F986B900DF04E8 /* AFURLSessionManager.h */,
+				74FD2FF517F986B900DF04E8 /* AFURLSessionManager.m */,
+			);
+			name = AFNetworking;
+			path = ../../AFNetworking/AFNetworking;
+			sourceTree = "<group>";
+		};
+		74FD2FFF17F986CA00DF04E8 /* AFIncrementalStore */ = {
+			isa = PBXGroup;
+			children = (
+				74FD300017F986CA00DF04E8 /* AFIncrementalStore.h */,
+				74FD300117F986CA00DF04E8 /* AFIncrementalStore.m */,
+				74FD300217F986CA00DF04E8 /* AFRESTClient.h */,
+				74FD300317F986CA00DF04E8 /* AFRESTClient.m */,
+			);
+			name = AFIncrementalStore;
+			path = ../../AFIncrementalStore;
+			sourceTree = "<group>";
+		};
 		F81D903916F3DED80043C85A /* TransformerKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -203,63 +221,6 @@
 			name = Models;
 			sourceTree = "<group>";
 		};
-		F8AD92C215D9A0B400402FE9 /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				BD19795417CF968400958CDC /* AFNetworkActivityIndicatorManager.h */,
-				BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */,
-				BD19795617CF968400958CDC /* UIActivityIndicatorView+AFNetworking.h */,
-				BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */,
-				BD19795817CF968400958CDC /* UIButton+AFNetworking.h */,
-				BD19795917CF968400958CDC /* UIButton+AFNetworking.m */,
-				BD19795A17CF968400958CDC /* UIImageView+AFNetworking.h */,
-				BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */,
-				BD19795C17CF968400958CDC /* UIProgressView+AFNetworking.h */,
-				BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */,
-				BD19795E17CF968400958CDC /* UIWebView+AFNetworking.h */,
-				BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */,
-				BD19794517CF965C00958CDC /* AFEventSource.h */,
-				BD19794617CF965C00958CDC /* AFEventSource.m */,
-				BD19794717CF965C00958CDC /* AFHTTPClient+Rocket.h */,
-				BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */,
-				BD19794917CF965C00958CDC /* AFJSONPatchSerializer.h */,
-				BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */,
-				BD19794B17CF965C00958CDC /* AFSerialization.h */,
-				BD19794C17CF965C00958CDC /* AFSerialization.m */,
-				BD19794D17CF965C00958CDC /* AFURLSessionManager.h */,
-				BD19794E17CF965C00958CDC /* AFURLSessionManager.m */,
-				F8AD92C315D9A0B400402FE9 /* AFHTTPClient.h */,
-				F8AD92C415D9A0B400402FE9 /* AFHTTPClient.m */,
-				F8AD92C515D9A0B400402FE9 /* AFHTTPRequestOperation.h */,
-				F8AD92C615D9A0B400402FE9 /* AFHTTPRequestOperation.m */,
-				F8AD92C715D9A0B400402FE9 /* AFImageRequestOperation.h */,
-				F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */,
-				F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */,
-				F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */,
-				F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */,
-				F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */,
-				F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */,
-				F8AD92D215D9A0B400402FE9 /* AFURLConnectionOperation.h */,
-				F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */,
-				F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */,
-				F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */,
-			);
-			name = AFNetworking;
-			path = ../../AFNetworking/AFNetworking;
-			sourceTree = "<group>";
-		};
-		F8AD92E215D9A0BB00402FE9 /* AFIncrementalStore */ = {
-			isa = PBXGroup;
-			children = (
-				F8AD92E315D9A0BB00402FE9 /* AFIncrementalStore.h */,
-				F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */,
-				F8AD92E515D9A0BB00402FE9 /* AFRESTClient.h */,
-				F8AD92E615D9A0BB00402FE9 /* AFRESTClient.m */,
-			);
-			name = AFIncrementalStore;
-			path = ../../AFIncrementalStore;
-			sourceTree = "<group>";
-		};
 		F8AFAFA215AB4F28003FE5BB = {
 			isa = PBXGroup;
 			children = (
@@ -282,6 +243,7 @@
 		F8AFAFB015AB4F28003FE5BB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				74FD2FE017F9799100DF04E8 /* Security.framework */,
 				F81D905D16F3E6C10043C85A /* MobileCoreServices.framework */,
 				F81D905B16F3E6BC0043C85A /* SystemConfiguration.framework */,
 				F8AFAFB115AB4F28003FE5BB /* UIKit.framework */,
@@ -322,8 +284,10 @@
 		F8AFB07215AB5010003FE5BB /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
-				F8AD92E215D9A0BB00402FE9 /* AFIncrementalStore */,
-				F8AD92C215D9A0B400402FE9 /* AFNetworking */,
+				74FD300617F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.h */,
+				74FD300717F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.m */,
+				74FD2FFF17F986CA00DF04E8 /* AFIncrementalStore */,
+				74FD2FE217F986B900DF04E8 /* AFNetworking */,
 				F81D904416F3DEEB0043C85A /* InflectorKit */,
 				F81D903916F3DED80043C85A /* TransformerKit */,
 			);
@@ -357,7 +321,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = AF;
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = F8AFAFA715AB4F28003FE5BB /* Build configuration list for PBXProject "Basic Example" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -394,39 +358,31 @@
 			files = (
 				F8874F1415B08B770048680F /* Artist.m in Sources */,
 				F8874F1515B08B770048680F /* ArtistDetailViewController.m in Sources */,
-				BD19796117CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */,
 				F8874F1615B08B770048680F /* ArtistsListViewController.m in Sources */,
+				74FD2FF817F986B900DF04E8 /* AFHTTPSessionManager.m in Sources */,
 				F8874F1815B08B770048680F /* Song.m in Sources */,
+				74FD300517F986CA00DF04E8 /* AFRESTClient.m in Sources */,
+				74FD2FF917F986B900DF04E8 /* AFNetworkReachabilityManager.m in Sources */,
+				74FD2FF617F986B900DF04E8 /* AFHTTPRequestOperation.m in Sources */,
+				74FD300817F98CB400DF04E8 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				74FD2FFC17F986B900DF04E8 /* AFURLRequestSerialization.m in Sources */,
+				74FD2FFB17F986B900DF04E8 /* AFURLConnectionOperation.m in Sources */,
+				74FD2FFE17F986B900DF04E8 /* AFURLSessionManager.m in Sources */,
 				F8874F1915B08B770048680F /* SongAPIClient.m in Sources */,
-				BD19796217CF968400958CDC /* UIButton+AFNetworking.m in Sources */,
-				BD19795317CF965C00958CDC /* AFURLSessionManager.m in Sources */,
-				BD19796417CF968400958CDC /* UIProgressView+AFNetworking.m in Sources */,
 				F8874F1A15B08B770048680F /* SongsIncrementalStore.m in Sources */,
 				F8874F2015B08C4B0048680F /* AppDelegate.m in Sources */,
 				F8874F1F15B08C2A0048680F /* main.m in Sources */,
 				F8874F2315B08CA80048680F /* IncrementalStoreExample.xcdatamodeld in Sources */,
-				BD19795117CF965C00958CDC /* AFJSONPatchSerializer.m in Sources */,
-				F8AD92D815D9A0B400402FE9 /* AFHTTPClient.m in Sources */,
-				F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */,
-				F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */,
-				BD19796517CF968400958CDC /* UIWebView+AFNetworking.m in Sources */,
-				BD19796017CF968400958CDC /* AFNetworkActivityIndicatorManager.m in Sources */,
-				F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */,
-				F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */,
-				F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */,
-				F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */,
-				F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */,
-				F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */,
 				F81D904116F3DED80043C85A /* NSValueTransformer+TransformerKit.m in Sources */,
 				F81D904916F3DEEB0043C85A /* NSString+InflectorKit.m in Sources */,
-				BD19795217CF965C00958CDC /* AFSerialization.m in Sources */,
 				F81D904A16F3DEEB0043C85A /* TTTStringInflector.m in Sources */,
 				F8F8240D173893C000ED7E21 /* TTTDateTransformers.m in Sources */,
+				74FD2FFA17F986B900DF04E8 /* AFSecurityPolicy.m in Sources */,
+				74FD300417F986CA00DF04E8 /* AFIncrementalStore.m in Sources */,
 				F8F8240E173893C000ED7E21 /* TTTImageTransformers.m in Sources */,
-				BD19795017CF965C00958CDC /* AFHTTPClient+Rocket.m in Sources */,
+				74FD2FF717F986B900DF04E8 /* AFHTTPRequestOperationManager.m in Sources */,
 				F8F8240F173893C000ED7E21 /* TTTStringTransformers.m in Sources */,
-				BD19796317CF968400958CDC /* UIImageView+AFNetworking.m in Sources */,
-				BD19794F17CF965C00958CDC /* AFEventSource.m in Sources */,
+				74FD2FFD17F986B900DF04E8 /* AFURLResponseSerialization.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -437,9 +393,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -454,10 +411,14 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -466,9 +427,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -476,8 +438,11 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
@@ -489,10 +454,13 @@
 		F8AFAFCB15AB4F28003FE5BB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../AFNetworking/";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -500,10 +468,13 @@
 		F8AFAFCC15AB4F28003FE5BB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../AFNetworking/";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
+++ b/Examples/Basic Example/Basic Example.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD19794F17CF965C00958CDC /* AFEventSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794617CF965C00958CDC /* AFEventSource.m */; };
+		BD19795017CF965C00958CDC /* AFHTTPClient+Rocket.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */; };
+		BD19795117CF965C00958CDC /* AFJSONPatchSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */; };
+		BD19795217CF965C00958CDC /* AFSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794C17CF965C00958CDC /* AFSerialization.m */; };
+		BD19795317CF965C00958CDC /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19794E17CF965C00958CDC /* AFURLSessionManager.m */; };
+		BD19796017CF968400958CDC /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */; };
+		BD19796117CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */; };
+		BD19796217CF968400958CDC /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795917CF968400958CDC /* UIButton+AFNetworking.m */; };
+		BD19796317CF968400958CDC /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */; };
+		BD19796417CF968400958CDC /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */; };
+		BD19796517CF968400958CDC /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */; };
 		F81D904116F3DED80043C85A /* NSValueTransformer+TransformerKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D903B16F3DED80043C85A /* NSValueTransformer+TransformerKit.m */; };
 		F81D904916F3DEEB0043C85A /* NSString+InflectorKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904616F3DEEB0043C85A /* NSString+InflectorKit.m */; };
 		F81D904A16F3DEEB0043C85A /* TTTStringInflector.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904816F3DEEB0043C85A /* TTTStringInflector.m */; };
@@ -26,11 +37,9 @@
 		F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C615D9A0B400402FE9 /* AFHTTPRequestOperation.m */; };
 		F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */; };
 		F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */; };
-		F8AD92DD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */; };
 		F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */; };
 		F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */; };
 		F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */; };
-		F8AD92E115D9A0B400402FE9 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */; };
 		F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */; };
 		F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E615D9A0BB00402FE9 /* AFRESTClient.m */; };
 		F8AFAFB215AB4F28003FE5BB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AFAFB115AB4F28003FE5BB /* UIKit.framework */; };
@@ -43,6 +52,28 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD19794517CF965C00958CDC /* AFEventSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFEventSource.h; sourceTree = "<group>"; };
+		BD19794617CF965C00958CDC /* AFEventSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFEventSource.m; sourceTree = "<group>"; };
+		BD19794717CF965C00958CDC /* AFHTTPClient+Rocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AFHTTPClient+Rocket.h"; sourceTree = "<group>"; };
+		BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AFHTTPClient+Rocket.m"; sourceTree = "<group>"; };
+		BD19794917CF965C00958CDC /* AFJSONPatchSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONPatchSerializer.h; sourceTree = "<group>"; };
+		BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONPatchSerializer.m; sourceTree = "<group>"; };
+		BD19794B17CF965C00958CDC /* AFSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSerialization.h; sourceTree = "<group>"; };
+		BD19794C17CF965C00958CDC /* AFSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSerialization.m; sourceTree = "<group>"; };
+		BD19794D17CF965C00958CDC /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
+		BD19794E17CF965C00958CDC /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
+		BD19795417CF968400958CDC /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		BD19795617CF968400958CDC /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19795817CF968400958CDC /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19795917CF968400958CDC /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19795A17CF968400958CDC /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19795C17CF968400958CDC /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19795E17CF968400958CDC /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		F81D903A16F3DED80043C85A /* NSValueTransformer+TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValueTransformer+TransformerKit.h"; sourceTree = "<group>"; };
 		F81D903B16F3DED80043C85A /* NSValueTransformer+TransformerKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValueTransformer+TransformerKit.m"; sourceTree = "<group>"; };
 		F81D904016F3DED80043C85A /* TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformerKit.h; sourceTree = "<group>"; };
@@ -79,8 +110,6 @@
 		F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
 		F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92CD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
 		F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
 		F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
@@ -88,8 +117,6 @@
 		F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
 		F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92D615D9A0B400402FE9 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		F8AD92E315D9A0BB00402FE9 /* AFIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFIncrementalStore.h; sourceTree = "<group>"; };
 		F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFIncrementalStore.m; sourceTree = "<group>"; };
 		F8AD92E515D9A0BB00402FE9 /* AFRESTClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFRESTClient.h; sourceTree = "<group>"; };
@@ -179,6 +206,28 @@
 		F8AD92C215D9A0B400402FE9 /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
+				BD19795417CF968400958CDC /* AFNetworkActivityIndicatorManager.h */,
+				BD19795517CF968400958CDC /* AFNetworkActivityIndicatorManager.m */,
+				BD19795617CF968400958CDC /* UIActivityIndicatorView+AFNetworking.h */,
+				BD19795717CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m */,
+				BD19795817CF968400958CDC /* UIButton+AFNetworking.h */,
+				BD19795917CF968400958CDC /* UIButton+AFNetworking.m */,
+				BD19795A17CF968400958CDC /* UIImageView+AFNetworking.h */,
+				BD19795B17CF968400958CDC /* UIImageView+AFNetworking.m */,
+				BD19795C17CF968400958CDC /* UIProgressView+AFNetworking.h */,
+				BD19795D17CF968400958CDC /* UIProgressView+AFNetworking.m */,
+				BD19795E17CF968400958CDC /* UIWebView+AFNetworking.h */,
+				BD19795F17CF968400958CDC /* UIWebView+AFNetworking.m */,
+				BD19794517CF965C00958CDC /* AFEventSource.h */,
+				BD19794617CF965C00958CDC /* AFEventSource.m */,
+				BD19794717CF965C00958CDC /* AFHTTPClient+Rocket.h */,
+				BD19794817CF965C00958CDC /* AFHTTPClient+Rocket.m */,
+				BD19794917CF965C00958CDC /* AFJSONPatchSerializer.h */,
+				BD19794A17CF965C00958CDC /* AFJSONPatchSerializer.m */,
+				BD19794B17CF965C00958CDC /* AFSerialization.h */,
+				BD19794C17CF965C00958CDC /* AFSerialization.m */,
+				BD19794D17CF965C00958CDC /* AFURLSessionManager.h */,
+				BD19794E17CF965C00958CDC /* AFURLSessionManager.m */,
 				F8AD92C315D9A0B400402FE9 /* AFHTTPClient.h */,
 				F8AD92C415D9A0B400402FE9 /* AFHTTPClient.m */,
 				F8AD92C515D9A0B400402FE9 /* AFHTTPRequestOperation.h */,
@@ -187,8 +236,6 @@
 				F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */,
 				F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */,
 				F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */,
-				F8AD92CD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.h */,
-				F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */,
 				F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */,
 				F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */,
 				F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */,
@@ -196,8 +243,6 @@
 				F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */,
 				F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */,
 				F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */,
-				F8AD92D615D9A0B400402FE9 /* UIImageView+AFNetworking.h */,
-				F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */,
 			);
 			name = AFNetworking;
 			path = ../../AFNetworking/AFNetworking;
@@ -349,30 +394,39 @@
 			files = (
 				F8874F1415B08B770048680F /* Artist.m in Sources */,
 				F8874F1515B08B770048680F /* ArtistDetailViewController.m in Sources */,
+				BD19796117CF968400958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */,
 				F8874F1615B08B770048680F /* ArtistsListViewController.m in Sources */,
 				F8874F1815B08B770048680F /* Song.m in Sources */,
 				F8874F1915B08B770048680F /* SongAPIClient.m in Sources */,
+				BD19796217CF968400958CDC /* UIButton+AFNetworking.m in Sources */,
+				BD19795317CF965C00958CDC /* AFURLSessionManager.m in Sources */,
+				BD19796417CF968400958CDC /* UIProgressView+AFNetworking.m in Sources */,
 				F8874F1A15B08B770048680F /* SongsIncrementalStore.m in Sources */,
 				F8874F2015B08C4B0048680F /* AppDelegate.m in Sources */,
 				F8874F1F15B08C2A0048680F /* main.m in Sources */,
 				F8874F2315B08CA80048680F /* IncrementalStoreExample.xcdatamodeld in Sources */,
+				BD19795117CF965C00958CDC /* AFJSONPatchSerializer.m in Sources */,
 				F8AD92D815D9A0B400402FE9 /* AFHTTPClient.m in Sources */,
 				F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */,
 				F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */,
+				BD19796517CF968400958CDC /* UIWebView+AFNetworking.m in Sources */,
+				BD19796017CF968400958CDC /* AFNetworkActivityIndicatorManager.m in Sources */,
 				F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */,
-				F8AD92DD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m in Sources */,
 				F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */,
 				F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */,
 				F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */,
-				F8AD92E115D9A0B400402FE9 /* UIImageView+AFNetworking.m in Sources */,
 				F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */,
 				F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */,
 				F81D904116F3DED80043C85A /* NSValueTransformer+TransformerKit.m in Sources */,
 				F81D904916F3DEEB0043C85A /* NSString+InflectorKit.m in Sources */,
+				BD19795217CF965C00958CDC /* AFSerialization.m in Sources */,
 				F81D904A16F3DEEB0043C85A /* TTTStringInflector.m in Sources */,
 				F8F8240D173893C000ED7E21 /* TTTDateTransformers.m in Sources */,
 				F8F8240E173893C000ED7E21 /* TTTImageTransformers.m in Sources */,
+				BD19795017CF965C00958CDC /* AFHTTPClient+Rocket.m in Sources */,
 				F8F8240F173893C000ED7E21 /* TTTStringTransformers.m in Sources */,
+				BD19796317CF968400958CDC /* UIImageView+AFNetworking.m in Sources */,
+				BD19794F17CF965C00958CDC /* AFEventSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/Basic Example/Classes/SongAPIClient.m
+++ b/Examples/Basic Example/Classes/SongAPIClient.m
@@ -43,8 +43,9 @@ static NSString * const kAFIncrementalStoreExampleAPIBaseURLString = @"http://af
         return nil;
     }
     
-    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
-    [self setDefaultHeader:@"Accept" value:@"application/json"];
+    [self setResponseSerializer:[AFJSONSerializer serializer]];
+//    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
+//    [self setDefaultHeader:@"Accept" value:@"application/json"];
     
     return self;
 }

--- a/Examples/Basic Example/Classes/SongAPIClient.m
+++ b/Examples/Basic Example/Classes/SongAPIClient.m
@@ -43,7 +43,7 @@ static NSString * const kAFIncrementalStoreExampleAPIBaseURLString = @"http://af
         return nil;
     }
     
-    [self setResponseSerializer:[AFJSONSerializer serializer]];
+    [self setResponseSerializer:[AFJSONResponseSerializer serializer]];
 //    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
 //    [self setDefaultHeader:@"Accept" value:@"application/json"];
     

--- a/Examples/CheckIns Example/CheckIns Example.xcodeproj/project.pbxproj
+++ b/Examples/CheckIns Example/CheckIns Example.xcodeproj/project.pbxproj
@@ -7,6 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD19798717CF994C00958CDC /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F889213D161E117C00D11FD2 /* Default-568h@2x.png */; };
+		BD19799417CF997700958CDC /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19798A17CF997700958CDC /* AFNetworkActivityIndicatorManager.m */; };
+		BD19799517CF997700958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19798C17CF997700958CDC /* UIActivityIndicatorView+AFNetworking.m */; };
+		BD19799617CF997700958CDC /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19798E17CF997700958CDC /* UIButton+AFNetworking.m */; };
+		BD19799717CF997700958CDC /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19798F17CF997700958CDC /* UIImageView+AFNetworking.m */; };
+		BD19799817CF997700958CDC /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19799117CF997700958CDC /* UIProgressView+AFNetworking.m */; };
+		BD19799917CF997700958CDC /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19799317CF997700958CDC /* UIWebView+AFNetworking.m */; };
+		BD1979A417CF998C00958CDC /* AFEventSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19799B17CF998C00958CDC /* AFEventSource.m */; };
+		BD1979A517CF998C00958CDC /* AFHTTPClient+Rocket.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19799D17CF998C00958CDC /* AFHTTPClient+Rocket.m */; };
+		BD1979A617CF998C00958CDC /* AFJSONPatchSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19799F17CF998C00958CDC /* AFJSONPatchSerializer.m */; };
+		BD1979A717CF998C00958CDC /* AFSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = BD1979A117CF998C00958CDC /* AFSerialization.m */; };
+		BD1979A817CF998C00958CDC /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD1979A317CF998C00958CDC /* AFURLSessionManager.m */; };
+		BD1979AA17CF9B1E00958CDC /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD1979A917CF9B1E00958CDC /* Security.framework */; };
+		BD1979AC17CF9B2900958CDC /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD1979AB17CF9B2900958CDC /* CFNetwork.framework */; };
+		BD1979AE17CF9D6800958CDC /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD1979AD17CF9D6800958CDC /* MobileCoreServices.framework */; };
 		F81D902B16F3DECE0043C85A /* NSValueTransformer+TransformerKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D902516F3DECE0043C85A /* NSValueTransformer+TransformerKit.m */; };
 		F81D905716F3DEF60043C85A /* NSString+InflectorKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D905416F3DEF60043C85A /* NSString+InflectorKit.m */; };
 		F81D905816F3DEF60043C85A /* TTTStringInflector.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D905616F3DEF60043C85A /* TTTStringInflector.m */; };
@@ -26,11 +41,9 @@
 		F8B77D71161E178D00A88B7F /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D60161E178D00A88B7F /* AFHTTPRequestOperation.m */; };
 		F8B77D72161E178D00A88B7F /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D62161E178D00A88B7F /* AFImageRequestOperation.m */; };
 		F8B77D73161E178D00A88B7F /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D64161E178D00A88B7F /* AFJSONRequestOperation.m */; };
-		F8B77D74161E178D00A88B7F /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D66161E178D00A88B7F /* AFNetworkActivityIndicatorManager.m */; };
 		F8B77D75161E178D00A88B7F /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D69161E178D00A88B7F /* AFPropertyListRequestOperation.m */; };
 		F8B77D76161E178D00A88B7F /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D6B161E178D00A88B7F /* AFURLConnectionOperation.m */; };
 		F8B77D77161E178D00A88B7F /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D6D161E178D00A88B7F /* AFXMLRequestOperation.m */; };
-		F8B77D78161E178D00A88B7F /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D6F161E178D00A88B7F /* UIImageView+AFNetworking.m */; };
 		F8B77D7B161E17AF00A88B7F /* CheckIns.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F8B77D79161E17AF00A88B7F /* CheckIns.xcdatamodeld */; };
 		F8B77D98161E43EC00A88B7F /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B77D97161E43EC00A88B7F /* SystemConfiguration.framework */; };
 		F8F8241F173893E600ED7E21 /* TTTDateTransformers.m in Sources */ = {isa = PBXBuildFile; fileRef = F8F8241C173893E600ED7E21 /* TTTDateTransformers.m */; };
@@ -39,6 +52,31 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD19798817CF997700958CDC /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19798917CF997700958CDC /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		BD19798A17CF997700958CDC /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		BD19798B17CF997700958CDC /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19798C17CF997700958CDC /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19798D17CF997700958CDC /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19798E17CF997700958CDC /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19798F17CF997700958CDC /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19799017CF997700958CDC /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19799117CF997700958CDC /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19799217CF997700958CDC /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19799317CF997700958CDC /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19799A17CF998C00958CDC /* AFEventSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFEventSource.h; sourceTree = "<group>"; };
+		BD19799B17CF998C00958CDC /* AFEventSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFEventSource.m; sourceTree = "<group>"; };
+		BD19799C17CF998C00958CDC /* AFHTTPClient+Rocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AFHTTPClient+Rocket.h"; sourceTree = "<group>"; };
+		BD19799D17CF998C00958CDC /* AFHTTPClient+Rocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AFHTTPClient+Rocket.m"; sourceTree = "<group>"; };
+		BD19799E17CF998C00958CDC /* AFJSONPatchSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONPatchSerializer.h; sourceTree = "<group>"; };
+		BD19799F17CF998C00958CDC /* AFJSONPatchSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONPatchSerializer.m; sourceTree = "<group>"; };
+		BD1979A017CF998C00958CDC /* AFSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSerialization.h; sourceTree = "<group>"; };
+		BD1979A117CF998C00958CDC /* AFSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSerialization.m; sourceTree = "<group>"; };
+		BD1979A217CF998C00958CDC /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
+		BD1979A317CF998C00958CDC /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
+		BD1979A917CF9B1E00958CDC /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		BD1979AB17CF9B2900958CDC /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		BD1979AD17CF9D6800958CDC /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		F81D902416F3DECE0043C85A /* NSValueTransformer+TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValueTransformer+TransformerKit.h"; sourceTree = "<group>"; };
 		F81D902516F3DECE0043C85A /* NSValueTransformer+TransformerKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValueTransformer+TransformerKit.m"; sourceTree = "<group>"; };
 		F81D902A16F3DECE0043C85A /* TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformerKit.h; sourceTree = "<group>"; };
@@ -79,8 +117,6 @@
 		F8B77D62161E178D00A88B7F /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
 		F8B77D63161E178D00A88B7F /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
 		F8B77D64161E178D00A88B7F /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		F8B77D65161E178D00A88B7F /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		F8B77D66161E178D00A88B7F /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
 		F8B77D67161E178D00A88B7F /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
 		F8B77D68161E178D00A88B7F /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
 		F8B77D69161E178D00A88B7F /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
@@ -88,8 +124,6 @@
 		F8B77D6B161E178D00A88B7F /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
 		F8B77D6C161E178D00A88B7F /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
 		F8B77D6D161E178D00A88B7F /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		F8B77D6E161E178D00A88B7F /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		F8B77D6F161E178D00A88B7F /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		F8B77D7A161E17AF00A88B7F /* CheckIns.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CheckIns.xcdatamodel; sourceTree = "<group>"; };
 		F8B77D97161E43EC00A88B7F /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		F8F82419173893E600ED7E21 /* TTTDateTransformers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTDateTransformers.h; sourceTree = "<group>"; };
@@ -105,6 +139,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD1979AE17CF9D6800958CDC /* MobileCoreServices.framework in Frameworks */,
+				BD1979AC17CF9B2900958CDC /* CFNetwork.framework in Frameworks */,
+				BD1979AA17CF9B1E00958CDC /* Security.framework in Frameworks */,
 				F8B77D98161E43EC00A88B7F /* SystemConfiguration.framework in Frameworks */,
 				F8892111161E113100D11FD2 /* UIKit.framework in Frameworks */,
 				F8892113161E113100D11FD2 /* Foundation.framework in Frameworks */,
@@ -166,6 +203,9 @@
 		F889210F161E113100D11FD2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BD1979AD17CF9D6800958CDC /* MobileCoreServices.framework */,
+				BD1979AB17CF9B2900958CDC /* CFNetwork.framework */,
+				BD1979A917CF9B1E00958CDC /* Security.framework */,
 				F8B77D97161E43EC00A88B7F /* SystemConfiguration.framework */,
 				F8892110161E113100D11FD2 /* UIKit.framework */,
 				F8892112161E113100D11FD2 /* Foundation.framework */,
@@ -251,6 +291,28 @@
 		F8B77D5C161E178D00A88B7F /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
+				BD19799A17CF998C00958CDC /* AFEventSource.h */,
+				BD19799B17CF998C00958CDC /* AFEventSource.m */,
+				BD19799C17CF998C00958CDC /* AFHTTPClient+Rocket.h */,
+				BD19799D17CF998C00958CDC /* AFHTTPClient+Rocket.m */,
+				BD19799E17CF998C00958CDC /* AFJSONPatchSerializer.h */,
+				BD19799F17CF998C00958CDC /* AFJSONPatchSerializer.m */,
+				BD1979A017CF998C00958CDC /* AFSerialization.h */,
+				BD1979A117CF998C00958CDC /* AFSerialization.m */,
+				BD1979A217CF998C00958CDC /* AFURLSessionManager.h */,
+				BD1979A317CF998C00958CDC /* AFURLSessionManager.m */,
+				BD19798817CF997700958CDC /* UIImageView+AFNetworking.h */,
+				BD19798917CF997700958CDC /* AFNetworkActivityIndicatorManager.h */,
+				BD19798A17CF997700958CDC /* AFNetworkActivityIndicatorManager.m */,
+				BD19798B17CF997700958CDC /* UIActivityIndicatorView+AFNetworking.h */,
+				BD19798C17CF997700958CDC /* UIActivityIndicatorView+AFNetworking.m */,
+				BD19798D17CF997700958CDC /* UIButton+AFNetworking.h */,
+				BD19798E17CF997700958CDC /* UIButton+AFNetworking.m */,
+				BD19798F17CF997700958CDC /* UIImageView+AFNetworking.m */,
+				BD19799017CF997700958CDC /* UIProgressView+AFNetworking.h */,
+				BD19799117CF997700958CDC /* UIProgressView+AFNetworking.m */,
+				BD19799217CF997700958CDC /* UIWebView+AFNetworking.h */,
+				BD19799317CF997700958CDC /* UIWebView+AFNetworking.m */,
 				F8B77D5D161E178D00A88B7F /* AFHTTPClient.h */,
 				F8B77D5E161E178D00A88B7F /* AFHTTPClient.m */,
 				F8B77D5F161E178D00A88B7F /* AFHTTPRequestOperation.h */,
@@ -259,8 +321,6 @@
 				F8B77D62161E178D00A88B7F /* AFImageRequestOperation.m */,
 				F8B77D63161E178D00A88B7F /* AFJSONRequestOperation.h */,
 				F8B77D64161E178D00A88B7F /* AFJSONRequestOperation.m */,
-				F8B77D65161E178D00A88B7F /* AFNetworkActivityIndicatorManager.h */,
-				F8B77D66161E178D00A88B7F /* AFNetworkActivityIndicatorManager.m */,
 				F8B77D67161E178D00A88B7F /* AFNetworking.h */,
 				F8B77D68161E178D00A88B7F /* AFPropertyListRequestOperation.h */,
 				F8B77D69161E178D00A88B7F /* AFPropertyListRequestOperation.m */,
@@ -268,8 +328,6 @@
 				F8B77D6B161E178D00A88B7F /* AFURLConnectionOperation.m */,
 				F8B77D6C161E178D00A88B7F /* AFXMLRequestOperation.h */,
 				F8B77D6D161E178D00A88B7F /* AFXMLRequestOperation.m */,
-				F8B77D6E161E178D00A88B7F /* UIImageView+AFNetworking.h */,
-				F8B77D6F161E178D00A88B7F /* UIImageView+AFNetworking.m */,
 			);
 			name = AFNetworking;
 			path = ../../AFNetworking/AFNetworking;
@@ -301,7 +359,7 @@
 		F8892103161E113100D11FD2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = AFNetworking;
 			};
 			buildConfigurationList = F8892106161E113100D11FD2 /* Build configuration list for PBXProject "CheckIns Example" */;
@@ -326,6 +384,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD19798717CF994C00958CDC /* Default-568h@2x.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -337,26 +396,35 @@
 			buildActionMask = 2147483647;
 			files = (
 				F889214B161E121500D11FD2 /* AppDelegate.m in Sources */,
+				BD19799717CF997700958CDC /* UIImageView+AFNetworking.m in Sources */,
+				BD19799617CF997700958CDC /* UIButton+AFNetworking.m in Sources */,
+				BD1979A517CF998C00958CDC /* AFHTTPClient+Rocket.m in Sources */,
 				F8892149161E11CE00D11FD2 /* main.m in Sources */,
 				F8892156161E126200D11FD2 /* CheckInsViewController.m in Sources */,
 				F8892157161E126200D11FD2 /* CheckIn.m in Sources */,
 				F8892158161E126200D11FD2 /* CheckInsAPIClient.m in Sources */,
 				F8892159161E126200D11FD2 /* CheckInsIncrementalStore.m in Sources */,
+				BD19799517CF997700958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */,
 				F8B77D5A161E178600A88B7F /* AFIncrementalStore.m in Sources */,
 				F8B77D5B161E178600A88B7F /* AFRESTClient.m in Sources */,
 				F8B77D70161E178D00A88B7F /* AFHTTPClient.m in Sources */,
+				BD1979A617CF998C00958CDC /* AFJSONPatchSerializer.m in Sources */,
 				F8B77D71161E178D00A88B7F /* AFHTTPRequestOperation.m in Sources */,
+				BD1979A817CF998C00958CDC /* AFURLSessionManager.m in Sources */,
 				F8B77D72161E178D00A88B7F /* AFImageRequestOperation.m in Sources */,
 				F8B77D73161E178D00A88B7F /* AFJSONRequestOperation.m in Sources */,
-				F8B77D74161E178D00A88B7F /* AFNetworkActivityIndicatorManager.m in Sources */,
+				BD1979A717CF998C00958CDC /* AFSerialization.m in Sources */,
+				BD19799417CF997700958CDC /* AFNetworkActivityIndicatorManager.m in Sources */,
 				F8B77D75161E178D00A88B7F /* AFPropertyListRequestOperation.m in Sources */,
 				F8B77D76161E178D00A88B7F /* AFURLConnectionOperation.m in Sources */,
+				BD1979A417CF998C00958CDC /* AFEventSource.m in Sources */,
 				F8B77D77161E178D00A88B7F /* AFXMLRequestOperation.m in Sources */,
-				F8B77D78161E178D00A88B7F /* UIImageView+AFNetworking.m in Sources */,
 				F8B77D7B161E17AF00A88B7F /* CheckIns.xcdatamodeld in Sources */,
 				F81D902B16F3DECE0043C85A /* NSValueTransformer+TransformerKit.m in Sources */,
 				F81D905716F3DEF60043C85A /* NSString+InflectorKit.m in Sources */,
+				BD19799817CF997700958CDC /* UIProgressView+AFNetworking.m in Sources */,
 				F81D905816F3DEF60043C85A /* TTTStringInflector.m in Sources */,
+				BD19799917CF997700958CDC /* UIWebView+AFNetworking.m in Sources */,
 				F8F8241F173893E600ED7E21 /* TTTDateTransformers.m in Sources */,
 				F8F82420173893E600ED7E21 /* TTTImageTransformers.m in Sources */,
 				F8F82421173893E600ED7E21 /* TTTStringTransformers.m in Sources */,
@@ -389,6 +457,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;

--- a/Examples/CheckIns Example/Classes/CheckInsAPIClient.m
+++ b/Examples/CheckIns Example/Classes/CheckInsAPIClient.m
@@ -42,11 +42,13 @@ static NSString * const kAFIncrementalStoreExampleAPIBaseURLString = @"http://lo
         return nil;
     }
     
-    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
-    [self setDefaultHeader:@"Accept" value:@"application/json"];
+    [self setResponseSerializer:[AFJSONSerializer serializer]];
+//    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
+//    [self setDefaultHeader:@"Accept" value:@"application/json"];
     
+    __weak AFHTTPClient *__weak_self = self;
     [self setReachabilityStatusChangeBlock:^(AFNetworkReachabilityStatus status) {
-        self.operationQueue.suspended = (status == AFNetworkReachabilityStatusNotReachable);
+        __weak_self.operationQueue.suspended = (status == AFNetworkReachabilityStatusNotReachable);
     }];
     
     return self;

--- a/Examples/Twitter Client/Activity Stream Example.xcodeproj/project.pbxproj
+++ b/Examples/Twitter Client/Activity Stream Example.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD19797217CF985E00958CDC /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19796717CF985D00958CDC /* AFNetworkActivityIndicatorManager.m */; };
+		BD19797317CF985E00958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19796917CF985D00958CDC /* UIActivityIndicatorView+AFNetworking.m */; };
+		BD19797417CF985E00958CDC /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19796B17CF985D00958CDC /* UIButton+AFNetworking.m */; };
+		BD19797517CF985E00958CDC /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19796D17CF985D00958CDC /* UIImageView+AFNetworking.m */; };
+		BD19797617CF985E00958CDC /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19796F17CF985D00958CDC /* UIProgressView+AFNetworking.m */; };
+		BD19797717CF985E00958CDC /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19797117CF985D00958CDC /* UIWebView+AFNetworking.m */; };
+		BD19798217CF988400958CDC /* AFEventSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19797917CF988400958CDC /* AFEventSource.m */; };
+		BD19798317CF988400958CDC /* AFHTTPClient+Rocket.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19797B17CF988400958CDC /* AFHTTPClient+Rocket.m */; };
+		BD19798417CF988400958CDC /* AFJSONPatchSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19797D17CF988400958CDC /* AFJSONPatchSerializer.m */; };
+		BD19798517CF988400958CDC /* AFSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19797F17CF988400958CDC /* AFSerialization.m */; };
+		BD19798617CF988400958CDC /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19798117CF988400958CDC /* AFURLSessionManager.m */; };
+		BD1979B017CFA13100958CDC /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD1979AF17CFA13100958CDC /* CFNetwork.framework */; };
+		BD1979B217CFA13800958CDC /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD1979B117CFA13800958CDC /* Security.framework */; };
 		F81D903616F3DED30043C85A /* NSValueTransformer+TransformerKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D903016F3DED30043C85A /* NSValueTransformer+TransformerKit.m */; };
 		F81D905016F3DEF00043C85A /* NSString+InflectorKit.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904D16F3DEF00043C85A /* NSString+InflectorKit.m */; };
 		F81D905116F3DEF00043C85A /* TTTStringInflector.m in Sources */ = {isa = PBXBuildFile; fileRef = F81D904F16F3DEF00043C85A /* TTTStringInflector.m */; };
@@ -24,11 +37,9 @@
 		F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C615D9A0B400402FE9 /* AFHTTPRequestOperation.m */; };
 		F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */; };
 		F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */; };
-		F8AD92DD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */; };
 		F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */; };
 		F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */; };
 		F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */; };
-		F8AD92E115D9A0B400402FE9 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */; };
 		F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */; };
 		F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92E615D9A0BB00402FE9 /* AFRESTClient.m */; };
 		F8AD92F815D9A2DB00402FE9 /* Post.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AD92F715D9A2DB00402FE9 /* Post.m */; };
@@ -45,6 +56,30 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD19796617CF985D00958CDC /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		BD19796717CF985D00958CDC /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "../UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		BD19796817CF985D00958CDC /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19796917CF985D00958CDC /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19796A17CF985D00958CDC /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19796B17CF985D00958CDC /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "../UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19796C17CF985D00958CDC /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19796D17CF985D00958CDC /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19796E17CF985D00958CDC /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19796F17CF985D00958CDC /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19797017CF985D00958CDC /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		BD19797117CF985D00958CDC /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "../UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		BD19797817CF988400958CDC /* AFEventSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFEventSource.h; sourceTree = "<group>"; };
+		BD19797917CF988400958CDC /* AFEventSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFEventSource.m; sourceTree = "<group>"; };
+		BD19797A17CF988400958CDC /* AFHTTPClient+Rocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AFHTTPClient+Rocket.h"; sourceTree = "<group>"; };
+		BD19797B17CF988400958CDC /* AFHTTPClient+Rocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AFHTTPClient+Rocket.m"; sourceTree = "<group>"; };
+		BD19797C17CF988400958CDC /* AFJSONPatchSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONPatchSerializer.h; sourceTree = "<group>"; };
+		BD19797D17CF988400958CDC /* AFJSONPatchSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONPatchSerializer.m; sourceTree = "<group>"; };
+		BD19797E17CF988400958CDC /* AFSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFSerialization.h; sourceTree = "<group>"; };
+		BD19797F17CF988400958CDC /* AFSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFSerialization.m; sourceTree = "<group>"; };
+		BD19798017CF988400958CDC /* AFURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLSessionManager.h; sourceTree = "<group>"; };
+		BD19798117CF988400958CDC /* AFURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLSessionManager.m; sourceTree = "<group>"; };
+		BD1979AF17CFA13100958CDC /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		BD1979B117CFA13800958CDC /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		F81D902F16F3DED30043C85A /* NSValueTransformer+TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValueTransformer+TransformerKit.h"; sourceTree = "<group>"; };
 		F81D903016F3DED30043C85A /* NSValueTransformer+TransformerKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValueTransformer+TransformerKit.m"; sourceTree = "<group>"; };
 		F81D903516F3DED30043C85A /* TransformerKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformerKit.h; sourceTree = "<group>"; };
@@ -77,8 +112,6 @@
 		F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
 		F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92CD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
 		F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
 		F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
@@ -86,8 +119,6 @@
 		F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
 		F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
 		F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		F8AD92D615D9A0B400402FE9 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		F8AD92E315D9A0BB00402FE9 /* AFIncrementalStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFIncrementalStore.h; sourceTree = "<group>"; };
 		F8AD92E415D9A0BB00402FE9 /* AFIncrementalStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFIncrementalStore.m; sourceTree = "<group>"; };
 		F8AD92E515D9A0BB00402FE9 /* AFRESTClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFRESTClient.h; sourceTree = "<group>"; };
@@ -116,6 +147,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD1979B217CFA13800958CDC /* Security.framework in Frameworks */,
+				BD1979B017CFA13100958CDC /* CFNetwork.framework in Frameworks */,
 				F8B6873616F2981B001909E6 /* SystemConfiguration.framework in Frameworks */,
 				F8B6873416F29811001909E6 /* MobileCoreServices.framework in Frameworks */,
 				F8AFAFB215AB4F28003FE5BB /* UIKit.framework in Frameworks */,
@@ -208,6 +241,28 @@
 		F8AD92C215D9A0B400402FE9 /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
+				BD19797817CF988400958CDC /* AFEventSource.h */,
+				BD19797917CF988400958CDC /* AFEventSource.m */,
+				BD19797A17CF988400958CDC /* AFHTTPClient+Rocket.h */,
+				BD19797B17CF988400958CDC /* AFHTTPClient+Rocket.m */,
+				BD19797C17CF988400958CDC /* AFJSONPatchSerializer.h */,
+				BD19797D17CF988400958CDC /* AFJSONPatchSerializer.m */,
+				BD19797E17CF988400958CDC /* AFSerialization.h */,
+				BD19797F17CF988400958CDC /* AFSerialization.m */,
+				BD19798017CF988400958CDC /* AFURLSessionManager.h */,
+				BD19798117CF988400958CDC /* AFURLSessionManager.m */,
+				BD19796617CF985D00958CDC /* AFNetworkActivityIndicatorManager.h */,
+				BD19796717CF985D00958CDC /* AFNetworkActivityIndicatorManager.m */,
+				BD19796817CF985D00958CDC /* UIActivityIndicatorView+AFNetworking.h */,
+				BD19796917CF985D00958CDC /* UIActivityIndicatorView+AFNetworking.m */,
+				BD19796A17CF985D00958CDC /* UIButton+AFNetworking.h */,
+				BD19796B17CF985D00958CDC /* UIButton+AFNetworking.m */,
+				BD19796C17CF985D00958CDC /* UIImageView+AFNetworking.h */,
+				BD19796D17CF985D00958CDC /* UIImageView+AFNetworking.m */,
+				BD19796E17CF985D00958CDC /* UIProgressView+AFNetworking.h */,
+				BD19796F17CF985D00958CDC /* UIProgressView+AFNetworking.m */,
+				BD19797017CF985D00958CDC /* UIWebView+AFNetworking.h */,
+				BD19797117CF985D00958CDC /* UIWebView+AFNetworking.m */,
 				F8AD92C315D9A0B400402FE9 /* AFHTTPClient.h */,
 				F8AD92C415D9A0B400402FE9 /* AFHTTPClient.m */,
 				F8AD92C515D9A0B400402FE9 /* AFHTTPRequestOperation.h */,
@@ -216,8 +271,6 @@
 				F8AD92C815D9A0B400402FE9 /* AFImageRequestOperation.m */,
 				F8AD92C915D9A0B400402FE9 /* AFJSONRequestOperation.h */,
 				F8AD92CA15D9A0B400402FE9 /* AFJSONRequestOperation.m */,
-				F8AD92CD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.h */,
-				F8AD92CE15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m */,
 				F8AD92CF15D9A0B400402FE9 /* AFNetworking.h */,
 				F8AD92D015D9A0B400402FE9 /* AFPropertyListRequestOperation.h */,
 				F8AD92D115D9A0B400402FE9 /* AFPropertyListRequestOperation.m */,
@@ -225,8 +278,6 @@
 				F8AD92D315D9A0B400402FE9 /* AFURLConnectionOperation.m */,
 				F8AD92D415D9A0B400402FE9 /* AFXMLRequestOperation.h */,
 				F8AD92D515D9A0B400402FE9 /* AFXMLRequestOperation.m */,
-				F8AD92D615D9A0B400402FE9 /* UIImageView+AFNetworking.h */,
-				F8AD92D715D9A0B400402FE9 /* UIImageView+AFNetworking.m */,
 			);
 			name = AFNetworking;
 			path = ../../AFNetworking/AFNetworking;
@@ -266,6 +317,8 @@
 		F8AFAFB015AB4F28003FE5BB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BD1979B117CFA13800958CDC /* Security.framework */,
+				BD1979AF17CFA13100958CDC /* CFNetwork.framework */,
 				F8B6873516F2981B001909E6 /* SystemConfiguration.framework */,
 				F8B6873316F29811001909E6 /* MobileCoreServices.framework */,
 				F8AFAFB115AB4F28003FE5BB /* UIKit.framework */,
@@ -381,23 +434,31 @@
 			files = (
 				F8478A69162729B80026615F /* AppDotNet.xcdatamodeld in Sources */,
 				F8874F1615B08B770048680F /* GlobalStreamViewController.m in Sources */,
+				BD19797717CF985E00958CDC /* UIWebView+AFNetworking.m in Sources */,
+				BD19797417CF985E00958CDC /* UIButton+AFNetworking.m in Sources */,
 				F8874F1915B08B770048680F /* AppDotNetAPIClient.m in Sources */,
 				F8874F1A15B08B770048680F /* AppDotNetIncrementalStore.m in Sources */,
 				F8874F2015B08C4B0048680F /* AppDelegate.m in Sources */,
 				F8874F1F15B08C2A0048680F /* main.m in Sources */,
 				F8AD92D815D9A0B400402FE9 /* AFHTTPClient.m in Sources */,
+				BD19798417CF988400958CDC /* AFJSONPatchSerializer.m in Sources */,
+				BD19798617CF988400958CDC /* AFURLSessionManager.m in Sources */,
+				BD19798317CF988400958CDC /* AFHTTPClient+Rocket.m in Sources */,
 				F8AD92D915D9A0B400402FE9 /* AFHTTPRequestOperation.m in Sources */,
 				F8AD92DA15D9A0B400402FE9 /* AFImageRequestOperation.m in Sources */,
 				F8AD92DB15D9A0B400402FE9 /* AFJSONRequestOperation.m in Sources */,
-				F8AD92DD15D9A0B400402FE9 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				BD19798217CF988400958CDC /* AFEventSource.m in Sources */,
+				BD19797617CF985E00958CDC /* UIProgressView+AFNetworking.m in Sources */,
 				F8AD92DE15D9A0B400402FE9 /* AFPropertyListRequestOperation.m in Sources */,
+				BD19798517CF988400958CDC /* AFSerialization.m in Sources */,
 				F8AD92DF15D9A0B400402FE9 /* AFURLConnectionOperation.m in Sources */,
+				BD19797317CF985E00958CDC /* UIActivityIndicatorView+AFNetworking.m in Sources */,
 				F8AD92E015D9A0B400402FE9 /* AFXMLRequestOperation.m in Sources */,
-				F8AD92E115D9A0B400402FE9 /* UIImageView+AFNetworking.m in Sources */,
 				F8AD92E715D9A0BB00402FE9 /* AFIncrementalStore.m in Sources */,
 				F8AD92E815D9A0BB00402FE9 /* AFRESTClient.m in Sources */,
 				F8AD92F815D9A2DB00402FE9 /* Post.m in Sources */,
 				F8AD92FB15D9A2E500402FE9 /* User.m in Sources */,
+				BD19797517CF985E00958CDC /* UIImageView+AFNetworking.m in Sources */,
 				F87CD18E15DAB2B200E4C166 /* PostTableViewCell.m in Sources */,
 				F81D903616F3DED30043C85A /* NSValueTransformer+TransformerKit.m in Sources */,
 				F81D905016F3DEF00043C85A /* NSString+InflectorKit.m in Sources */,
@@ -405,6 +466,7 @@
 				F8F82416173893D400ED7E21 /* TTTDateTransformers.m in Sources */,
 				F8F82417173893D400ED7E21 /* TTTImageTransformers.m in Sources */,
 				F8F82418173893D400ED7E21 /* TTTStringTransformers.m in Sources */,
+				BD19797217CF985E00958CDC /* AFNetworkActivityIndicatorManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -470,6 +532,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -481,6 +544,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Examples/Twitter Client/AppDelegate.m
+++ b/Examples/Twitter Client/AppDelegate.m
@@ -23,6 +23,8 @@
 #import "AppDelegate.h"
 #import "AppDotNetIncrementalStore.h"
 #import "GlobalStreamViewController.h"
+#import "AFNetworkActivityIndicatorManager.h"
+
 
 @implementation AppDelegate
 @synthesize window = _window;

--- a/Examples/Twitter Client/Classes/AppDotNetAPIClient.m
+++ b/Examples/Twitter Client/Classes/AppDotNetAPIClient.m
@@ -44,8 +44,9 @@ static NSString * const kAFAppDotNetAPIBaseURLString = @"https://alpha-api.app.n
         return nil;
     }
     
-    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
-    [self setDefaultHeader:@"Accept" value:@"application/json"];
+    [self setResponseSerializer:[AFJSONSerializer serializer]];
+//    [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
+//    [self setDefaultHeader:@"Accept" value:@"application/json"];
     
     return self;
 }


### PR DESCRIPTION
This a next (hacky) version of @Nitewriter's https://github.com/AFNetworking/AFIncrementalStore/pull/242 that maps `AFRestClient` to `AFHTTPRequestOperationManager`.

I have only tested this with the 'Basic Example' so code reviews/tests are really appreciated.

Really want to know the actual port approach that the author wants to take. I suppose taking advantage of `NSURLSession` is really desired.
