### PR TITLE
Prevent waiting on main context while inserting new objects

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -422,7 +422,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
                 childContext.parentContext = context;
                 childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
 
-                [childContext performBlockAndWait:^{
+                [childContext performBlock:^{
                     [self insertOrUpdateObjectsFromRepresentations:representationOrArrayOfRepresentations ofEntity:fetchRequest.entity fromResponse:operation.response withContext:childContext error:nil completionBlock:^(NSArray *managedObjects, NSArray *backingObjects) {
                         NSSet *childObjects = [childContext registeredObjects];
                         AFSaveManagedObjectContextOrThrowInternalConsistencyException(childContext);


### PR DESCRIPTION
Why are we creating a child context with a private queue only to make our main queue wait? I know this fix seems daft, but this has solved all of my UI locking problems when making fetch requests with many relationships / many objects. It seems safe as we refresh the objects in the main context when we've finished inserting in the child context, which is what we're supposed to do. What am I missing?
