### PR TITLE
Set value for relationships when they're faults

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -256,7 +256,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
     NSMutableDictionary *mutableRelationshipValues = [[NSMutableDictionary alloc] init];
     for (NSRelationshipDescription *relationship in [managedObject.entity.relationshipsByName allValues]) {
         
-        if ([managedObject hasFaultForRelationshipNamed:relationship.name]) {
+        if ([managedObject hasFaultForRelationshipNamed:relationship.name] && [backingObject valueForKey:relationship.name]) {
             continue;
         }
         


### PR DESCRIPTION
The previous condition skipped values that were faults for relationships, but when the value if for a required relationship it will cause a silent error when trying to save the backing context if it wasn't previously set.
