### PR TITLE
added prefix header contents to supress warnings over AFIncrementalStore

### DIFF
--- a/AFIncrementalStore.podspec
+++ b/AFIncrementalStore.podspec
@@ -19,4 +19,18 @@ Pod::Spec.new do |s|
   s.dependency 'AFNetworking', '~> 1.3.2'
   s.dependency 'InflectorKit'
   s.dependency 'TransformerKit'
+
+  s.prefix_header_contents = <<-EOS
+#import <Availability.h>
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <MobileCoreServices/MobileCoreServices.h>
+  #import <Security/Security.h>
+#else
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <CoreServices/CoreServices.h>
+  #import <Security/Security.h>
+#endif
+EOS
 end

--- a/AFIncrementalStore/AFRESTClient.m
+++ b/AFIncrementalStore/AFRESTClient.m
@@ -24,27 +24,6 @@
 
 #import "TTTDateTransformers.h"
 
-static NSString * AFQueryByAppendingParameters(NSString *query, NSDictionary *parameters) {
-    static NSCharacterSet *_componentSeparatorCharacterSet = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        _componentSeparatorCharacterSet = [NSCharacterSet characterSetWithCharactersInString:@"&"];
-    });
-    
-    if (!parameters || [parameters count] == 0) {
-        return query;
-    }
-    
-    query = query ? [[query stringByTrimmingCharactersInSet:_componentSeparatorCharacterSet] stringByAppendingString:@"&"] : @"";
-    
-    NSMutableArray *mutablePairs = [NSMutableArray arrayWithCapacity:[parameters count]];
-    [parameters enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
-        [mutablePairs addObject:[NSString stringWithFormat:@"%@=%@", field, value]];
-    }];
-
-    return [query stringByAppendingString:[mutablePairs componentsJoinedByString:@"&"]];
-}
-
 @interface AFRESTClient ()
 @property (readwrite, nonatomic, strong) TTTStringInflector *inflector;
 @end


### PR DESCRIPTION
I found that adding these lines to the prefix header got rid of warnings about SystemConfiguration and MobileCoreServices frameworks not being available, despite them being available with AFNetworking.
