### PR TITLE
Fix #233: Remove cached backing ObjectIDs when they are unregistered

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.m
+++ b/AFIncrementalStore/AFIncrementalStore.m
@@ -927,6 +927,7 @@ withAttributeAndRelationshipValuesFromManagedObject:(NSManagedObject *)managedOb
     
     for (NSManagedObjectID *objectID in objectIDs) {
         [[_registeredObjectIDsByEntityNameAndNestedResourceIdentifier objectForKey:objectID.entity.name] removeObjectForKey:AFResourceIdentifierFromReferenceObject([self referenceObjectForObjectID:objectID])];
+        [_backingObjectIDByObjectID removeObjectForKey:objectID];
     }
 }
 


### PR DESCRIPTION
When objects were unregistered from AFIncrementalStore, references to the unregistered objects' ObjectIDs were left in `_backingObjectIDByObjectID`. Since the objects were unregistered (and most likely deleted from the backing store), inconsistencies would arise when objects that were deleted from the backing store were recreated (for instance if an object was removed from a relationship on the remote server, deleted locally, and then added back) as discussed in #233.

It appears that when an objectID is recreated, it still hashes equal to the previous objectID for an object with the same resource identifier, so `_backingObjectIDByObjectID` would return an objectID referring to an object deleted from the backing store. This change removes the backing object ID from the cache when the objectID is unregistered.
